### PR TITLE
fix: Update Close logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ ECP relies on the `certificate_config.json` file to read all the metadata inform
 {
   "cert_configs": {
     "macos_keychain": {
-      "issuer": "YOUR_CERT_ISSUER",
-    },
+      "issuer": "YOUR_CERT_ISSUER"
+    }
   },
   "libs": {
       "ecp": "~/.config/gcloud/enterprise_cert/ecp",
       "ecp_client": "~/.config/gcloud/enterprise_cert/libecp.dylib",
-      "tls_offload": "~/.config/gcloud/enterprise_cert/libtls_offload.dylib",
+      "tls_offload": "~/.config/gcloud/enterprise_cert/libtls_offload.dylib"
   },
-  "version": 1,
+  "version": 1
 }
 ```
 
@@ -83,15 +83,15 @@ ECP relies on the `certificate_config.json` file to read all the metadata inform
     "windows_store": {
       "store": "MY",
       "provider": "current_user",
-      "issuer": "YOUR_CERT_ISSUER",
-    },
+      "issuer": "YOUR_CERT_ISSUER"
+    }
   },
   "libs": {
       "ecp": "%AppData%/gcloud/enterprise_cert/ecp.exe",
       "ecp_client": "%AppData%/gcloud/enterprise_cert/libecp.dll",
-      "tls_offload": "%AppData%/gcloud/enterprise_cert/libtls_offload.dll",
+      "tls_offload": "%AppData%/gcloud/enterprise_cert/libtls_offload.dll"
   },
-  "version": 1,
+  "version": 1
 }
 ```
 
@@ -103,15 +103,15 @@ ECP relies on the `certificate_config.json` file to read all the metadata inform
       "label": "YOUR_TOKEN_LABEL",
       "user_pin": "YOUR_PIN",
       "slot": "YOUR_SLOT",
-      "module": "The PKCS #11 module library file path",
-    },
+      "module": "The PKCS #11 module library file path"
+    }
   },
   "libs": {
       "ecp": "~/.config/gcloud/enterprise_cert/ecp",
       "ecp_client": "~/.config/gcloud/enterprise_cert/libecp.so",
-      "tls_offload": "~/.config/gcloud/enterprise_cert/libtls_offload.so",
+      "tls_offload": "~/.config/gcloud/enterprise_cert/libtls_offload.so"
   },
-  "version": 1,
+  "version": 1
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ gcloud config set context_aware/use_client_certificate true
 
 ### Certificate Configuration
 
-ECP relies on the `certificate_config.json` file to read all the metadata information of locating the certificate. The contents of this JSON file looks like the following:
+ECP relies on the `certificate_config.json` file to read all the metadata information for locating the certificate. The contents of this JSON file look like the following:
 
 #### MacOS (Keychain)
 
@@ -80,7 +80,7 @@ ECP relies on the `certificate_config.json` file to read all the metadata inform
 ```json
 {
   "cert_configs": {
-    "windows_my_store": {
+    "windows_store": {
       "store": "MY",
       "provider": "current_user",
       "issuer": "YOUR_CERT_ISSUER",
@@ -121,7 +121,8 @@ For amd64 MacOS, run `./build/scripts/darwin_amd64.sh`. The binaries will be pla
 
 For amd64 Linux, run `./build/scripts/linux_amd64.sh`. The binaries will be placed in `build/bin/linux_amd64` folder.
 
-For amd64 Windows, in powershell terminal, run `powershell.exe .\build\scripts\windows_amd64.sh`. The binaries will be placed in `build\bin\windows_amd64` folder.
+For amd64 Windows, in powershell terminal, run `.\build\scripts\windows_amd64.ps1`. The binaries will be placed in `build\bin\windows_amd64` folder.
+Note that gcc is required for compiling the Windows shared library. The easiest way to get gcc on Windows is to download Mingw64, and add "gcc.exe" to the powershell path.
 
 ## Contributing
 

--- a/client/client.go
+++ b/client/client.go
@@ -72,9 +72,9 @@ func (k *Key) Close() error {
 	if err := k.cmd.Process.Kill(); err != nil {
 		return fmt.Errorf("failed to kill signer process: %w", err)
 	}
-	if err := k.cmd.Wait(); err.Error() != "signal: killed" {
-		return fmt.Errorf("signer process was not killed: %w", err)
-	}
+	// Wait for cmd to exit and release resources. Since the process is forcefully killed, this
+	// will return a non-nil error (varies by OS), which we will ignore.
+	k.cmd.Wait()
 	// The Pipes connecting the RPC client should have been closed when the signer subprocess was killed.
 	// Calling `k.client.Close()` before `k.cmd.Process.Kill()` or `k.cmd.Wait()` _will_ cause a segfault.
 	if err := k.client.Close(); err.Error() != "close |0: file already closed" {

--- a/cshared/main.go
+++ b/cshared/main.go
@@ -31,7 +31,7 @@ func getCertPem(configFilePath string) []byte {
 		return nil
 	}
 	defer func() {
-		if key.Close() != nil {
+		if err = key.Close(); err != nil {
 			log.Printf("Failed to clean up key. %v", err)
 		}
 	}()
@@ -74,7 +74,7 @@ func SignForPython(configFilePath *C.char, digest *byte, digestLen int, sigHolde
 		return 0
 	}
 	defer func() {
-		if key.Close() != nil {
+		if err = key.Close(); err != nil {
 			log.Printf("Failed to clean up key. %v", err)
 		}
 	}()

--- a/internal/signer/darwin/keychain/keychain.go
+++ b/internal/signer/darwin/keychain/keychain.go
@@ -83,7 +83,7 @@ func cfErrorFromRef(cfErr C.CFErrorRef) *cfError {
 		return nil
 	}
 	c := &cfError{e: cfErr}
-	runtime.SetFinalizer(c, func(x any) {
+	runtime.SetFinalizer(c, func(x interface{}) {
 		C.CFRelease(C.CFTypeRef(x.(*cfError).e))
 	})
 	return c
@@ -142,7 +142,7 @@ func newKey(privateKeyRef C.SecKeyRef, certs []*x509.Certificate) (*Key, error) 
 	// This struct now owns the key reference. Retain now and release on
 	// finalise in case the credential gets forgotten about.
 	C.CFRetain(C.CFTypeRef(privateKeyRef))
-	runtime.SetFinalizer(k, func(x any) {
+	runtime.SetFinalizer(k, func(x interface{}) {
 		x.(*Key).Close()
 	})
 	return k, nil


### PR DESCRIPTION
Update Close logic to not check for exit error, since the error varies based on platform.
Fixed cshared client logging to correctly log closing errors.
Updated config json samples in README to not have trailing commas.