### PR TITLE
chore: Update license headers to be cross-compliant

### DIFF
--- a/build/scripts/darwin_amd64.sh
+++ b/build/scripts/darwin_amd64.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# Copyright 2022 Google LLC.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eu
 
 # Create a folder to hold the binaries

--- a/build/scripts/darwin_arm64.sh
+++ b/build/scripts/darwin_arm64.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# Copyright 2022 Google LLC.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eu
 
 # Create a folder to hold the binaries

--- a/build/scripts/linux_amd64.sh
+++ b/build/scripts/linux_amd64.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# Copyright 2022 Google LLC.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Create a folder to hold the binaries
 rm -rf ./build/bin/linux_amd64
 mkdir -p ./build/bin/linux_amd64

--- a/build/scripts/windows_amd64.ps1
+++ b/build/scripts/windows_amd64.ps1
@@ -1,3 +1,16 @@
+# Copyright 2022 Google LLC.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 $OutputFolder = ".\build\bin\windows_amd64"
 If (Test-Path $OutputFolder) {
     # Remove existing binaries

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,15 @@
 // Copyright 2022 Google LLC.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Package client is a cross-platform client for the signer binary (a.k.a."EnterpriseCertSigner").
 //

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,7 +1,16 @@
 // Copyright 2022 Google LLC.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // The tests in this file launches a mock signer binary "signer.go".
 package client
 

--- a/client/testdata/signer.sh
+++ b/client/testdata/signer.sh
@@ -1,7 +1,16 @@
 #!/bin/bash  
 
 # Copyright 2022 Google LLC.
-# Use of this source code is governed by a BSD-style
-# license that can be found in the LICENSE file.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 go run ../internal/signer/test/signer.go testdata/testcert.pem

--- a/client/util/util.go
+++ b/client/util/util.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package util provides helper functions for the client.
 package util
 

--- a/client/util/util_test.go
+++ b/client/util/util_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/cshared/main.go
+++ b/cshared/main.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This package is intended to be compiled into a C shared library for
 // use by non-Golang clients to perform certificate and signing operations.
 //

--- a/internal/signer/darwin/keychain/keychain.go
+++ b/internal/signer/darwin/keychain/keychain.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build darwin && cgo
 // +build darwin,cgo
 

--- a/internal/signer/darwin/keychain/keychain_test.go
+++ b/internal/signer/darwin/keychain/keychain_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build darwin && cgo
 // +build darwin,cgo
 

--- a/internal/signer/darwin/signer.go
+++ b/internal/signer/darwin/signer.go
@@ -1,7 +1,16 @@
 // Copyright 2022 Google LLC.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Signer.go is a net/rpc server that listens on stdin/stdout, exposing
 // methods that perform device certificate signing for Mac OS using keychain utils.
 // This server is intended to be launched as a subprocess by the signer client,

--- a/internal/signer/darwin/util/util.go
+++ b/internal/signer/darwin/util/util.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package util provides helper functions for the signer.
 package util
 

--- a/internal/signer/darwin/util/util_test.go
+++ b/internal/signer/darwin/util/util_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/internal/signer/linux/signer.go
+++ b/internal/signer/linux/signer.go
@@ -1,7 +1,16 @@
 // Copyright 2022 Google LLC.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Signer.go is a net/rpc server that listens on stdin/stdout, exposing
 // methods that perform device certificate signing for Linux using PKCS11
 // shared library.

--- a/internal/signer/linux/util/cert_util.go
+++ b/internal/signer/linux/util/cert_util.go
@@ -1,5 +1,17 @@
-// Cert_util provides helpers for working with certificates via PKCS11
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+// Cert_util provides helpers for working with certificates via PKCS11
 package util
 
 import (

--- a/internal/signer/linux/util/util.go
+++ b/internal/signer/linux/util/util.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package util provides helper functions for the signer.
 package util
 
@@ -31,10 +44,10 @@ type CertConfigs struct {
 
 // PKCS11 contains parameters describing the certificate to use.
 type PKCS11 struct {
-	Slot         string `json:"slot"`   // The hexadecimal representation of the uint36 slot ID. (ex:0x1739427)
-	Label        string `json:"label"`  // The token label (ex: gecc)
-	PKCS11Module string `json:"module"` // The path to the pkcs11 module (shared lib)
-	UserPin string `json:"user_pin"` // Optional user pin to unlock the PKCS #11 module. If it is not defined or empty C_Login will not be called.
+	Slot         string `json:"slot"`     // The hexadecimal representation of the uint36 slot ID. (ex:0x1739427)
+	Label        string `json:"label"`    // The token label (ex: gecc)
+	PKCS11Module string `json:"module"`   // The path to the pkcs11 module (shared lib)
+	UserPin      string `json:"user_pin"` // Optional user pin to unlock the PKCS #11 module. If it is not defined or empty C_Login will not be called.
 }
 
 // LoadConfig retrieves the ECP config file.

--- a/internal/signer/linux/util/util_test.go
+++ b/internal/signer/linux/util/util_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/internal/signer/test/signer.go
+++ b/internal/signer/test/signer.go
@@ -1,7 +1,16 @@
 // Copyright 2022 Google LLC.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // signer.go is a net/rpc server that listens on stdin/stdout, exposing
 // mock methods for testing client.go.
 package main

--- a/internal/signer/windows/ncrypt/cert_util.go
+++ b/internal/signer/windows/ncrypt/cert_util.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build windows
 // +build windows
 

--- a/internal/signer/windows/ncrypt/cert_util_test.go
+++ b/internal/signer/windows/ncrypt/cert_util_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build windows
 // +build windows
 

--- a/internal/signer/windows/ncrypt/ncrypt.go
+++ b/internal/signer/windows/ncrypt/ncrypt.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build windows
 // +build windows
 

--- a/internal/signer/windows/signer.go
+++ b/internal/signer/windows/signer.go
@@ -1,7 +1,16 @@
 // Copyright 2022 Google LLC.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Signer.go is a net/rpc server that listens on stdin/stdout, exposing
 // methods that perform device certificate signing for Windows OS using ncrypt utils.
 // This server is intended to be launched as a subprocess by the signer client,

--- a/internal/signer/windows/util/util.go
+++ b/internal/signer/windows/util/util.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package util provides helper functions for the signer.
 package util
 

--- a/internal/signer/windows/util/util_test.go
+++ b/internal/signer/windows/util/util_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (


### PR DESCRIPTION
Google OSS needs exact format for Apache 2.0 license header