### PR TITLE
fix: remove ecp.exe process checking/termination logic for windows

### DIFF
--- a/internal/signer/windows/signer.go
+++ b/internal/signer/windows/signer.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"signer/ncrypt"
 	"signer/util"
-	"time"
 )
 
 // If ECP Logging is enabled return true

--- a/internal/signer/windows/signer.go
+++ b/internal/signer/windows/signer.go
@@ -116,17 +116,5 @@ func main() {
 		log.Fatalf("Failed to register enterprise cert signer with net/rpc: %v", err)
 	}
 
-	// If the parent process dies, we should exit.
-	// We can detect this by periodically checking if the PID of the parent
-	// process is 1 (https://stackoverflow.com/a/2035683).
-	go func() {
-		for {
-			if os.Getppid() == 1 {
-				log.Fatalln("Enterprise cert signer's parent process died, exiting...")
-			}
-			time.Sleep(time.Second)
-		}
-	}()
-
 	rpc.ServeConn(&Connection{os.Stdin, os.Stdout})
 }


### PR DESCRIPTION
The ecp.exe process is alive and killed automatically so the for loop is not needed.