### PR TITLE
feat: Introduce darwin-specific client

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -28,4 +28,5 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: latest
+        working-directory: ./client
         args: -E gofmt --max-same-issues 0

--- a/build/scripts/darwin_amd64.sh
+++ b/build/scripts/darwin_amd64.sh
@@ -22,7 +22,7 @@ mkdir -p ./build/bin/darwin_amd64
 # Build the signer binary
 cd ./internal/signer/darwin
 go build
-mv signer ./../../../build/bin/darwin_amd64/ecp
+mv darwin ./../../../build/bin/darwin_amd64/ecp
 cd ./../../..
 
 # Build the signer library

--- a/build/scripts/darwin_arm64.sh
+++ b/build/scripts/darwin_arm64.sh
@@ -22,7 +22,7 @@ mkdir -p ./build/bin/darwin_arm64
 # Build the signer binary
 cd ./internal/signer/darwin
 CGO_ENABLED=1 GO111MODULE=on GOARCH=arm64 go build
-mv signer ./../../../build/bin/darwin_arm64/ecp
+mv darwin ./../../../build/bin/darwin_arm64/ecp
 cd ./../../..
 
 # Build the signer library

--- a/darwin/client.go
+++ b/darwin/client.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin && cgo
+// +build darwin,cgo
+
+// Package darwin contains a darwin-specific client for accessing the signer APIs directly,
+// bypassing the RPC-mechanims of the universal client.
+package darwin
+
+import (
+	"crypto"
+	"github.com/googleapis/enterprise-certificate-proxy/internal/signer/darwin/keychain"
+	"io"
+)
+
+// SecureKey is a public wrapper for the internal keychain implementation.
+type SecureKey struct {
+	key *keychain.Key
+}
+
+// CertificateChain returns the credential as a raw X509 cert chain. This contains the public key.
+func (sk *SecureKey) CertificateChain() [][]byte {
+	return sk.key.CertificateChain()
+}
+
+// Public returns the public key for this SecureKey.
+func (sk *SecureKey) Public() crypto.PublicKey {
+	return sk.key.Public()
+}
+
+// Sign signs a message digest, using the specified signer options.
+func (sk *SecureKey) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) (signed []byte, err error) {
+	return sk.key.Sign(nil, digest, opts)
+}
+
+// Close frees up resources associated with the underlying key.
+func (sk *SecureKey) Close() {
+	sk.key.Close()
+}
+
+// Cred gets the first Credential (filtering on issuer) corresponding to
+// available certificate and private key pairs (i.e. identities) available in
+// the Keychain. This includes both the current login keychain for the user,
+// and the system keychain.
+func NewSecureKey(issuerCN string) (*SecureKey, error) {
+	k, err := keychain.Cred(issuerCN)
+	return &SecureKey{key: k}, err
+}

--- a/darwin/client.go
+++ b/darwin/client.go
@@ -55,5 +55,8 @@ func (sk *SecureKey) Close() {
 // for the user as well as the system keychain.
 func NewSecureKey(issuerCN string) (*SecureKey, error) {
 	k, err := keychain.Cred(issuerCN)
+	if err != nil {
+		return nil, err
+	}
 	return &SecureKey{key: k}, err
 }

--- a/darwin/client.go
+++ b/darwin/client.go
@@ -20,8 +20,9 @@ package darwin
 
 import (
 	"crypto"
-	"github.com/googleapis/enterprise-certificate-proxy/internal/signer/darwin/keychain"
 	"io"
+
+	"github.com/googleapis/enterprise-certificate-proxy/internal/signer/darwin/keychain"
 )
 
 // SecureKey is a public wrapper for the internal keychain implementation.
@@ -49,10 +50,9 @@ func (sk *SecureKey) Close() {
 	sk.key.Close()
 }
 
-// Cred gets the first Credential (filtering on issuer) corresponding to
-// available certificate and private key pairs (i.e. identities) available in
-// the Keychain. This includes both the current login keychain for the user,
-// and the system keychain.
+// NewSecureKey returns a handle to the first available certificate and private key pair in
+// the MacOS Keychain matching the issuer filter. This includes both the current login keychain
+// for the user as well as the system keychain.
 func NewSecureKey(issuerCN string) (*SecureKey, error) {
 	k, err := keychain.Cred(issuerCN)
 	return &SecureKey{key: k}, err

--- a/darwin/client.go
+++ b/darwin/client.go
@@ -14,8 +14,8 @@
 //go:build darwin && cgo
 // +build darwin,cgo
 
-// Package darwin contains a darwin-specific client for accessing the signer APIs directly,
-// bypassing the RPC-mechanims of the universal client.
+// Package darwin contains a darwin-specific client for accessing the keychain APIs directly,
+// bypassing the RPC mechanism of the universal client.
 package darwin
 
 import (
@@ -30,7 +30,7 @@ type SecureKey struct {
 	key *keychain.Key
 }
 
-// CertificateChain returns the credential as a raw X509 cert chain. This contains the public key.
+// CertificateChain returns the SecureKey's raw X509 cert chain. This contains the public key.
 func (sk *SecureKey) CertificateChain() [][]byte {
 	return sk.key.CertificateChain()
 }
@@ -51,7 +51,7 @@ func (sk *SecureKey) Close() {
 }
 
 // NewSecureKey returns a handle to the first available certificate and private key pair in
-// the MacOS Keychain matching the issuer filter. This includes both the current login keychain
+// the MacOS Keychain matching the issuer CN filter. This includes both the current login keychain
 // for the user as well as the system keychain.
 func NewSecureKey(issuerCN string) (*SecureKey, error) {
 	k, err := keychain.Cred(issuerCN)

--- a/darwin/client.go
+++ b/darwin/client.go
@@ -58,5 +58,5 @@ func NewSecureKey(issuerCN string) (*SecureKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SecureKey{key: k}, err
+	return &SecureKey{key: k}, nil
 }

--- a/internal/signer/darwin/go.mod
+++ b/internal/signer/darwin/go.mod
@@ -1,3 +1,0 @@
-module signer
-
-go 1.19

--- a/internal/signer/darwin/signer.go
+++ b/internal/signer/darwin/signer.go
@@ -26,9 +26,10 @@ import (
 	"log"
 	"net/rpc"
 	"os"
-	"signer/keychain"
-	"signer/util"
 	"time"
+
+	"github.com/googleapis/enterprise-certificate-proxy/internal/signer/darwin/keychain"
+	"github.com/googleapis/enterprise-certificate-proxy/internal/signer/darwin/util"
 )
 
 // If ECP Logging is enabled return true


### PR DESCRIPTION
Introduces a darwin-specific client under the package name "darwin" for accessing the keychain APIs directly, bypassing the RPC mechanism of the universal client. 

In order to support this change, the submodule "internal/signer/darwin/go.mod" was deleted in order to make it's keychain package visible for import from the root module. Removing the submodule definition requires signer.go to use absolute import instead of relative import.

Note that this change will temporarily break the kokoro pipeline since copybara transforms would need to be updated.
Linux and Windows specific clients will be introduced if this refactoring is successful.

Usage:
import "github.com/googleapis/enterprise-certificate-proxy/darwin"