### PR TITLE
feat(darwin): Add support for keychain type (login vs system vs all)

### DIFF
--- a/darwin/client.go
+++ b/darwin/client.go
@@ -30,6 +30,12 @@ type SecureKey struct {
 	key *keychain.Key
 }
 
+// SecureKeyOptions encapsulates all supported keychain parameters
+type SecureKeyOptions struct {
+	IssuerCN     string
+	KeychainType string
+}
+
 // CertificateChain returns the SecureKey's raw X509 cert chain. This contains the public key.
 func (sk *SecureKey) CertificateChain() [][]byte {
 	return sk.key.CertificateChain()
@@ -64,7 +70,17 @@ func (sk *SecureKey) Close() {
 // the MacOS Keychain matching the issuer CN filter. This includes both the current login keychain
 // for the user as well as the system keychain.
 func NewSecureKey(issuerCN string) (*SecureKey, error) {
-	k, err := keychain.Cred(issuerCN)
+	k, err := keychain.Cred(issuerCN, "")
+	if err != nil {
+		return nil, err
+	}
+	return &SecureKey{key: k}, nil
+}
+
+// NewSecureKeyWithOptions returns a handle to the first available certificate and private key pair in
+// the MacOS Keychain matching the SecureKeyOptions filter.
+func NewSecureKeyWithOptions(options SecureKeyOptions) (*SecureKey, error) {
+	k, err := keychain.Cred(options.IssuerCN, options.KeychainType)
 	if err != nil {
 		return nil, err
 	}

--- a/darwin/client_test.go
+++ b/darwin/client_test.go
@@ -23,7 +23,7 @@ const testIssuer = "TestIssuer"
 func TestNewSecureKeyWithOptions(t *testing.T) {
 	opts := SecureKeyOptions{
 		IssuerCN:     testIssuer,
-		KeychainType: "login",
+		KeychainType: "all",
 	}
 	_, err := NewSecureKeyWithOptions(opts)
 	if err != nil {

--- a/darwin/client_test.go
+++ b/darwin/client_test.go
@@ -20,6 +20,18 @@ import (
 
 const testIssuer = "TestIssuer"
 
+func TestNewSecureKeyWithOptions(t *testing.T) {
+	opts := SecureKeyOptions{
+		IssuerCN:     testIssuer,
+		KeychainType: "login",
+	}
+	_, err := NewSecureKeyWithOptions(opts)
+	if err != nil {
+		t.Errorf("Cred: got %v, want nil err", err)
+		return
+	}
+}
+
 func TestClientEncrypt(t *testing.T) {
 	secureKey, err := NewSecureKey(testIssuer)
 	if err != nil {

--- a/internal/signer/darwin/keychain/keychain.go
+++ b/internal/signer/darwin/keychain/keychain.go
@@ -299,8 +299,7 @@ func findMatchingIdentities(keychainType string, issuerCN string) ([]C.SecIdenti
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("Error determining target keychain path: %w", err)
 		}
-		var filteredKeychainList C.CFMutableArrayRef
-		filteredKeychainList = C.CFArrayCreateMutable(C.kCFAllocatorDefault, 0, &C.kCFTypeArrayCallBacks)
+		filteredKeychainList := C.CFArrayCreateMutable(C.kCFAllocatorDefault, 0, &C.kCFTypeArrayCallBacks)
 		defer C.CFRelease(C.CFTypeRef(filteredKeychainList))
 		for i := 0; i < int(C.CFArrayGetCount(keychainList)); i++ {
 			keychainRef := C.CFArrayGetValueAtIndex(keychainList, C.CFIndex(i))

--- a/internal/signer/darwin/keychain/keychain.go
+++ b/internal/signer/darwin/keychain/keychain.go
@@ -23,7 +23,6 @@ package keychain
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>
-
 */
 import "C"
 

--- a/internal/signer/darwin/keychain/keychain.go
+++ b/internal/signer/darwin/keychain/keychain.go
@@ -23,6 +23,7 @@ package keychain
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>
+
 */
 import "C"
 
@@ -36,6 +37,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"time"
@@ -239,13 +242,36 @@ func (k *Key) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signa
 	return cfDataToBytes(C.CFDataRef(sig)), nil
 }
 
-// Cred gets the first Credential (filtering on issuer) corresponding to
-// available certificate and private key pairs (i.e. identities) available in
-// the Keychain. This includes both the current login keychain for the user,
-// and the system keychain.
-func Cred(issuerCN string) (*Key, error) {
+func getLoginKeychainPath() (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("could not get current user: %w", err)
+	}
+	return filepath.Join(usr.HomeDir, "Library", "Keychains", "login.keychain-db"), nil
+}
+
+func getSystemKeychainPath() (string, error) {
+	return "/Library/Keychains/System.keychain", nil
+}
+
+func getKeychainPath(keychainRef C.CFTypeRef) (string, error) {
+	var pathBuf [1024]C.char
+	pathLen := C.uint32_t(len(pathBuf))
+
+	status := C.SecKeychainGetPath(C.SecKeychainRef(keychainRef), &pathLen, &pathBuf[0])
+	if status != 0 {
+		return "", fmt.Errorf("SecKeychainGetPath failed: %d", status)
+	}
+
+	return C.GoStringN(&pathBuf[0], C.int(pathLen)), nil
+}
+
+// findMatchingIdentities returns a list of identities satisfying the keychainType and issuerCN criteria as "leafIdents".
+// It also returns the parsed leaf certificates as "leafs", and a pointer of the underlying "leafMatches" to be released by the caller.
+func findMatchingIdentities(keychainType string, issuerCN string) ([]C.SecIdentityRef, []*x509.Certificate, C.CFTypeRef, error) {
 	leafSearch := C.CFDictionaryCreateMutable(C.kCFAllocatorDefault, 5, &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
 	defer C.CFRelease(C.CFTypeRef(unsafe.Pointer(leafSearch)))
+
 	// Get identities (certificate + private key pairs).
 	C.CFDictionaryAddValue(leafSearch, unsafe.Pointer(C.kSecClass), unsafe.Pointer(C.kSecClassIdentity))
 	// Get identities that are signing capable.
@@ -254,30 +280,137 @@ func Cred(issuerCN string) (*Key, error) {
 	C.CFDictionaryAddValue(leafSearch, unsafe.Pointer(C.kSecReturnRef), unsafe.Pointer(C.kCFBooleanTrue))
 	// Be sure to list out all the matches.
 	C.CFDictionaryAddValue(leafSearch, unsafe.Pointer(C.kSecMatchLimit), unsafe.Pointer(C.kSecMatchLimitAll))
-	// Do the matching-item copy.
-	var leafMatches C.CFTypeRef
-	if errno := C.SecItemCopyMatching((C.CFDictionaryRef)(leafSearch), &leafMatches); errno != C.errSecSuccess {
-		return nil, keychainError(errno)
+
+	// Obtain the total keychain search space for the user as a list of keychains.
+	var keychainList C.CFArrayRef
+	if err := C.SecKeychainCopySearchList(&keychainList); err != C.errSecSuccess {
+		return nil, nil, 0, fmt.Errorf("failed to get keychain search list: %w", keychainError(err))
 	}
-	defer C.CFRelease(leafMatches)
+	defer C.CFRelease(C.CFTypeRef(keychainList))
+
+	// Filter for login vs system keychain search space.
+	if keychainType == "login" || keychainType == "system" {
+		var targetPath string
+		var err error
+		if keychainType == "login" {
+			targetPath, err = getLoginKeychainPath()
+		} else {
+			targetPath, err = getSystemKeychainPath()
+		}
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("Error determining target keychain path: %w", err)
+		}
+		var filteredKeychainList C.CFMutableArrayRef
+		filteredKeychainList = C.CFArrayCreateMutable(C.kCFAllocatorDefault, 0, &C.kCFTypeArrayCallBacks)
+		defer C.CFRelease(C.CFTypeRef(filteredKeychainList))
+		for i := 0; i < int(C.CFArrayGetCount(keychainList)); i++ {
+			keychainRef := C.CFArrayGetValueAtIndex(keychainList, C.CFIndex(i))
+			keychainPath, err := getKeychainPath(C.CFTypeRef(keychainRef))
+			if err != nil {
+				return nil, nil, 0, fmt.Errorf("Error extracting keychain path: %w", err)
+			}
+			if keychainPath == targetPath {
+				C.CFArrayAppendValue(filteredKeychainList, keychainRef)
+			}
+		}
+		keychainList = C.CFArrayRef(filteredKeychainList)
+	} else if keychainType != "all" && keychainType != "" {
+		return nil, nil, 0, fmt.Errorf("invalid keychain type: %s", keychainType)
+	}
+
+	// Restrict keychain search space
+	C.CFDictionaryAddValue(leafSearch, unsafe.Pointer(C.kSecMatchSearchList), unsafe.Pointer(keychainList))
+
+	var leafMatches C.CFTypeRef
+	if errno := C.SecItemCopyMatching(C.CFDictionaryRef(leafSearch), &leafMatches); errno != C.errSecSuccess {
+		return nil, nil, 0, fmt.Errorf("failed to find matching identities: %w", keychainError(errno))
+	}
+
 	signingIdents := C.CFArrayRef(leafMatches)
-	// Dump the certs into golang x509 Certificates.
-	var (
-		leafIdent C.SecIdentityRef
-		leaf      *x509.Certificate
-	)
-	// Find the first valid leaf whose issuer (CA) matches the name in filter.
-	// Validation in identityToX509 covers Not Before, Not After and key alg.
-	for i := 0; i < int(C.CFArrayGetCount(signingIdents)) && leaf == nil; i++ {
+	var leafIdents []C.SecIdentityRef
+	var leafs []*x509.Certificate
+
+	for i := 0; i < int(C.CFArrayGetCount(signingIdents)); i++ {
 		identDict := C.CFArrayGetValueAtIndex(signingIdents, C.CFIndex(i))
 		xc, err := identityToX509(C.SecIdentityRef(identDict))
 		if err != nil {
-			continue
+			continue // Skip this identity if there's an error
 		}
 		if xc.Issuer.CommonName == issuerCN {
-			leaf = xc
-			leafIdent = C.SecIdentityRef(identDict)
+			leafs = append(leafs, xc)
+			leafIdents = append(leafIdents, C.SecIdentityRef(identDict))
 		}
+	}
+
+	return leafIdents, leafs, leafMatches, nil
+}
+
+// compareCertificatesByRaw compares two certificates for exact byte-for-byte equality.
+// It returns true if and only if the certificates have identical DER-encoded representations.
+func compareCertificatesByRaw(cert1, cert2 *x509.Certificate) bool {
+	if cert1 == nil || cert2 == nil {
+		return cert1 == cert2 // True only if both are nil
+	}
+	return bytes.Equal(cert1.Raw, cert2.Raw)
+}
+
+// Cred gets the first Credential (filtering on issuer and keychainType) corresponding to
+// available certificate and private key pairs (i.e. identities) in
+// the Keychain. Accepted values for keychainType are "login", "system", and "all".
+// For backwards compatibility, an empty keychainType will be treated as "all".
+func Cred(issuerCN, keychainType string) (*Key, error) {
+	leafIdents, leafs, leafMatches, err := findMatchingIdentities(keychainType, issuerCN)
+	if err != nil {
+		return nil, err
+	}
+	defer C.CFRelease(leafMatches)
+
+	// If system keychain, we need to do an extra query for login, and subtract that from the final results.
+	// This is because of a quirk with Apple's kSecMatchSearchList API, which incorrectly returns results
+	// from both the login and system keychain when we retrict the search space to system only.
+	if keychainType == "system" {
+		loginLeafIdents, _, loginLeafMatches, err := findMatchingIdentities("login", issuerCN)
+		if err != nil {
+			return nil, err
+		}
+		defer C.CFRelease(loginLeafMatches)
+
+		var filteredLeafIdents []C.SecIdentityRef
+		var filteredLeafs []*x509.Certificate
+
+	outerLoop:
+		for i, systemIdent := range leafIdents {
+			systemCert, err1 := identityToX509(systemIdent)
+			if err1 != nil {
+				continue // Skip if we can't get the certificate
+			}
+			for _, loginIdent := range loginLeafIdents {
+				loginCert, err2 := identityToX509(loginIdent)
+				if err2 != nil {
+					continue //Skip if we can't get the certificate
+				}
+				if compareCertificatesByRaw(systemCert, loginCert) {
+					continue outerLoop // Found a match, skip this login identity.
+				}
+			}
+			// If we get here, no match was found in loginLeafIdents, so it's safe to append to our filtered results.
+			filteredLeafIdents = append(filteredLeafIdents, systemIdent)
+			filteredLeafs = append(filteredLeafs, leafs[i])
+		}
+
+		leafIdents = filteredLeafIdents
+		leafs = filteredLeafs
+	}
+
+	var leaf *x509.Certificate
+	var leafIdent C.SecIdentityRef
+
+	// Select the first match from the final results.
+	if len(leafs) > 0 {
+		leaf = leafs[0]
+		leafIdent = leafIdents[0]
+	} else {
+		return nil, fmt.Errorf("no key found with issuer common name %q", issuerCN)
 	}
 
 	caSearch := C.CFDictionaryCreateMutable(C.kCFAllocatorDefault, 0, &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)

--- a/internal/signer/darwin/keychain/keychain_test.go
+++ b/internal/signer/darwin/keychain/keychain_test.go
@@ -62,7 +62,7 @@ func TestImportPKCS12Cred(t *testing.T) {
 }
 
 func TestEncrypt(t *testing.T) {
-	key, err := Cred(testIssuer)
+	key, err := Cred(testIssuer, "")
 	if err != nil {
 		t.Errorf("Cred: got %v, want nil err", err)
 		return
@@ -76,7 +76,7 @@ func TestEncrypt(t *testing.T) {
 }
 
 func BenchmarkEncrypt(b *testing.B) {
-	key, err := Cred(testIssuer)
+	key, err := Cred(testIssuer, "")
 	if err != nil {
 		b.Errorf("Cred: got %v, want nil err", err)
 		return
@@ -91,7 +91,7 @@ func BenchmarkEncrypt(b *testing.B) {
 }
 
 func TestDecrypt(t *testing.T) {
-	key, err := Cred(testIssuer)
+	key, err := Cred(testIssuer, "")
 	if err != nil {
 		t.Errorf("Cred: got %v, want nil err", err)
 		return
@@ -109,7 +109,7 @@ func TestDecrypt(t *testing.T) {
 }
 
 func BenchmarkDecrypt(b *testing.B) {
-	key, err := Cred(testIssuer)
+	key, err := Cred(testIssuer, "")
 	if err != nil {
 		b.Errorf("Cred: got %v, want nil err", err)
 		return

--- a/internal/signer/darwin/signer.go
+++ b/internal/signer/darwin/signer.go
@@ -133,7 +133,7 @@ func main() {
 	}
 
 	enterpriseCertSigner := new(EnterpriseCertSigner)
-	enterpriseCertSigner.key, err = keychain.Cred(config.CertConfigs.MacOSKeychain.Issuer)
+	enterpriseCertSigner.key, err = keychain.Cred(config.CertConfigs.MacOSKeychain.Issuer, config.CertConfigs.MacOSKeychain.KeychainType)
 	if err != nil {
 		log.Fatalf("Failed to initialize enterprise cert signer using keychain: %v", err)
 	}

--- a/internal/signer/util/test_data/certificate_config.json
+++ b/internal/signer/util/test_data/certificate_config.json
@@ -1,7 +1,8 @@
 {
   "cert_configs": {
     "macos_keychain": {
-      "issuer": "Google Endpoint Verification"
+      "issuer": "Google Endpoint Verification",
+      "keychain_type": "system"
     },
     "windows_store": {
       "issuer": "enterprise_v1_corp_client",

--- a/internal/signer/util/util.go
+++ b/internal/signer/util/util.go
@@ -34,7 +34,8 @@ type CertConfigs struct {
 
 // MacOSKeychain contains keychain parameters describing the certificate to use.
 type MacOSKeychain struct {
-	Issuer string `json:"issuer"`
+	Issuer       string `json:"issuer"`
+	KeychainType string `json:"keychain_type"`
 }
 
 // WindowsStore contains Windows key store parameters describing the certificate to use.

--- a/internal/signer/util/util_test.go
+++ b/internal/signer/util/util_test.go
@@ -27,6 +27,10 @@ func TestLoadConfig(t *testing.T) {
 	if config.CertConfigs.MacOSKeychain.Issuer != want {
 		t.Errorf("Expected issuer is %q, got: %q", want, config.CertConfigs.MacOSKeychain.Issuer)
 	}
+	want = "system"
+	if config.CertConfigs.MacOSKeychain.KeychainType != want {
+		t.Errorf("Expected keychain type is %q, got: %q", want, config.CertConfigs.MacOSKeychain.KeychainType)
+	}
 
 	// windows
 	want = "enterprise_v1_corp_client"


### PR DESCRIPTION
If unspecified, we will search through all keychains, which is the existing behavior.

Implementation Note: Since there is a bug with a Apple's keychain selection API (which returns results from both login and system keychain even when restricting search to system only), we use a "subtraction" logic to remove login certs from the system query results.