### PR TITLE
ECP logging to only log when enabled.

### DIFF
--- a/internal/signer/darwin/signer.go
+++ b/internal/signer/darwin/signer.go
@@ -32,15 +32,32 @@ import (
 	"github.com/googleapis/enterprise-certificate-proxy/internal/signer/util"
 )
 
+
 // If ECP Logging is enabled return true
 // Otherwise return false
-func enableECPLogging() bool {
+func enabledECPLogging() bool {
 	if os.Getenv("ENABLE_ENTERPRISE_CERTIFICATE_LOGS") != "" {
 		return true
 	}
-
-	log.SetOutput(io.Discard)
 	return false
+}
+
+func ecpLogf(format string, v ...any) {
+	if enabledECPLogging() {
+		log.Printf(format, v...)
+	}
+}
+
+func ecpFatalln(v any) {
+	if enabledECPLogging() {
+		log.Fatalln(v)
+	}
+}
+
+func ecpFatalf(format string, v any) {
+	if enabledECPLogging() {
+		log.Fatalf(format, v)
+	}
 }
 
 func init() {
@@ -122,24 +139,23 @@ func (k *EnterpriseCertSigner) Decrypt(args DecryptArgs, resp *[]byte) (err erro
 }
 
 func main() {
-	enableECPLogging()
 	if len(os.Args) != 2 {
-		log.Fatalln("Signer is not meant to be invoked manually, exiting...")
+		ecpFatalln("Signer is not meant to be invoked manually, exiting...")
 	}
 	configFilePath := os.Args[1]
 	config, err := util.LoadConfig(configFilePath)
 	if err != nil {
-		log.Fatalf("Failed to load enterprise cert config: %v", err)
+		ecpFatalf("Failed to load enterprise cert config: %v", err)
 	}
 
 	enterpriseCertSigner := new(EnterpriseCertSigner)
 	enterpriseCertSigner.key, err = keychain.Cred(config.CertConfigs.MacOSKeychain.Issuer, config.CertConfigs.MacOSKeychain.KeychainType)
 	if err != nil {
-		log.Fatalf("Failed to initialize enterprise cert signer using keychain: %v", err)
+		ecpFatalf("Failed to initialize enterprise cert signer using keychain: %v", err)
 	}
 
 	if err := rpc.Register(enterpriseCertSigner); err != nil {
-		log.Fatalf("Failed to register enterprise cert signer with net/rpc: %v", err)
+		ecpFatalf("Failed to register enterprise cert signer with net/rpc: %v", err)
 	}
 
 	// If the parent process dies, we should exit.
@@ -148,7 +164,7 @@ func main() {
 	go func() {
 		for {
 			if os.Getppid() == 1 {
-				log.Fatalln("Enterprise cert signer's parent process died, exiting...")
+				ecpFatalln("Enterprise cert signer's parent process died, exiting...")
 			}
 			time.Sleep(time.Second)
 		}


### PR DESCRIPTION
This change introduces wrapper functions (`ecpLogf`, `ecpPrint`, `ecpFatalln`, `ecpFatalf`) that check the `ENABLE_ENTERPRISE_CERTIFICATE_LOGS` environment variable before writing to the log. This prevents unnecessary calls to `log.SetOutput(io.Discard)` and ensures that logging is consistently gated by the environment variable. The `enableECPLogging` function has been renamed to `enabledECPLogging` for clarity.