### PR TITLE
fix: Address  ImportPKCS12Cred failing tests

### DIFF
--- a/internal/signer/darwin/keychain/keychain.go
+++ b/internal/signer/darwin/keychain/keychain.go
@@ -762,9 +762,13 @@ func ImportPKCS12Cred(credPath string, password string) error {
 	defer C.CFRelease(C.CFTypeRef(optionsDict))
 
 	// 3. Import the .p12 data with password
-	status := C.SecPKCS12Import(bytesToCFData(keyData), optionsDict, nil)
+	var items C.CFArrayRef
+	status := C.SecPKCS12Import(bytesToCFData(keyData), optionsDict, &items)
 	if status != C.errSecSuccess {
 		return fmt.Errorf("failed to import PKCS#12 data: %s", osStatusDescription(status))
+	}
+	if items != 0 {
+		defer C.CFRelease(C.CFTypeRef(items))
 	}
 
 	return nil


### PR DESCRIPTION
**Problem**
`keychain.ImportPKCS12Cred` was failing with error: "One or more parameters passed to the function were not valid".

**Root Cause**
The C function `SecPKCS12Import` has a third parameter that is an "out parameter". This means it expects the memory address of a variable where it can place the results of the import—in this case, an array of the items it successfully imported from the .p12 file

The original code was passing nil for this third parameter. Previously, this was likely tolerated by the function. 

However, it appears that newer versions of macOS or its SDK now strictly require a valid pointer to be passed, even if you don't use the result. Passing nil became an invalid parameter, causing the function to fail. 

**Fix**
This PR provides a valid memory address for the function to write to. We  also added a defer `C.CFRelease` to properly clean up the memory allocated by the C function, preventing a memory leak.