### PR TITLE
build(ecp-http-proxy): build scripts generate ecp_http_proxy binary

### DIFF
--- a/build/scripts/darwin_amd64.sh
+++ b/build/scripts/darwin_amd64.sh
@@ -27,6 +27,12 @@ go build
 mv darwin ./../../../build/bin/darwin_amd64/ecp
 cd ./../../..
 
+# Build the ECP HTTP Proxy binary
+pushd http_proxy
+go build
+mv http_proxy ../build/bin/darwin_amd64/ecp_http_proxy
+popd
+
 # Build the signer library
 go build -buildmode=c-shared -buildmode=c-shared -ldflags="-X=main.Version=$CURRENT_TAG" -o build/bin/darwin_amd64/libecp.dylib cshared/main.go
 rm build/bin/darwin_amd64/libecp.h

--- a/build/scripts/darwin_arm64.sh
+++ b/build/scripts/darwin_arm64.sh
@@ -27,6 +27,12 @@ CGO_ENABLED=1 GO111MODULE=on GOARCH=arm64 go build
 mv darwin ./../../../build/bin/darwin_arm64/ecp
 cd ./../../..
 
+# Build the ECP HTTP Proxy binary
+pushd http_proxy
+CGO_ENABLED=1 GO111MODULE=on GOARCH=arm64 go build
+mv http_proxy ../build/bin/darwin_arm64/ecp_http_proxy
+popd
+
 # Build the signer library
 CGO_ENABLED=1 GO111MODULE=on GOARCH=arm64 go build -buildmode=c-shared -ldflags="-X=main.Version=$CURRENT_TAG" -o build/bin/darwin_arm64/libecp.dylib cshared/main.go
 rm build/bin/darwin_arm64/libecp.h

--- a/build/scripts/linux_amd64.sh
+++ b/build/scripts/linux_amd64.sh
@@ -25,6 +25,12 @@ mkdir -p ./build/bin/linux_amd64
 go build -buildmode=c-shared -ldflags="-X=main.Version=$CURRENT_TAG" -o build/bin/linux_amd64/libecp.so cshared/main.go
 rm build/bin/linux_amd64/libecp.h
 
+# Build the ECP HTTP Proxy binary
+pushd http_proxy
+go build
+mv http_proxy ../build/bin/linux_amd64/ecp_http_proxy
+popd
+
 # Build the signer binary
 cd ./internal/signer/linux
 go build

--- a/build/scripts/windows_amd64.ps1
+++ b/build/scripts/windows_amd64.ps1
@@ -26,6 +26,12 @@ go build
 Move-Item .\windows.exe ..\..\..\build\bin\windows_amd64\ecp.exe
 Set-Location ..\..\..\
 
+# Build the ECP HTTP Proxy binary
+Set-Location .\http_proxy
+go build
+Move-Item .\http_proxy.exe ..\build\bin\windows_amd64\ecp_http_proxy.exe
+Set-Location ..\
+
 # Build the signer library
 # TODO: Add build version to shared DLL. https://github.com/googleapis/enterprise-certificate-proxy/issues/103
 go build -buildmode=c-shared -o .\build\bin\windows_amd64\libecp.dll .\cshared\main.go


### PR DESCRIPTION
mac: 
- build/scripts/darwin_amd64.sh generates ecp_http_proxy
- build/scripts/darwin_arm64.sh generates ecp_http_proxy

linux: 
- build/scripts/linux_amd64.sh generates ecp_http_proxy

windows:
- build/scripts/windows_amd64.ps1 generates ecp_http_proxy.exe