### PR TITLE
perf: replace net/rpc with a lightweight gob RPC client to re-enable linker DCE

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/rpc"
 	"os"
 	"os/exec"
 
@@ -83,7 +82,7 @@ type DecryptArgs struct {
 // Key implements credential.Credential by holding the executed signer subprocess.
 type Key struct {
 	cmd       *exec.Cmd        // Pointer to the signer subprocess.
-	client    *rpc.Client      // Pointer to the rpc client that communicates with the signer subprocess.
+	client    *rpcClient       // Pointer to the rpc client that communicates with the signer subprocess.
 	publicKey crypto.PublicKey // Public key of loaded certificate.
 	chain     [][]byte         // Certificate chain of loaded certificate.
 }
@@ -179,7 +178,7 @@ func Cred(configFilePath string) (*Key, error) {
 	if err != nil {
 		return nil, err
 	}
-	k.client = rpc.NewClient(&Connection{kout, kin})
+	k.client = newRPCClient(&Connection{kout, kin})
 
 	if err := k.cmd.Start(); err != nil {
 		return nil, fmt.Errorf("starting enterprise cert signer subprocess: %w", err)

--- a/client/rpclite.go
+++ b/client/rpclite.go
@@ -1,0 +1,97 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+// rpclite is a minimal RPC client that speaks the same gob-based wire protocol
+// as net/rpc but does not import net/rpc itself. This avoids pulling in
+// net/rpc's debug HTTP handler which depends on html/template, a known blocker
+// for the Go linker's method dead code elimination (DCE) optimization.
+//
+// Wire protocol (identical to net/rpc):
+//   - Client sends: gob-encoded request header, then gob-encoded args
+//   - Server sends: gob-encoded response header, then gob-encoded reply
+//
+// The request/response structs mirror net/rpc.Request and net/rpc.Response
+// exactly, so this client is compatible with existing net/rpc servers.
+
+import (
+	"encoding/gob"
+	"errors"
+	"io"
+	"sync"
+)
+
+// request mirrors net/rpc.Request — must match exactly for wire compatibility.
+type request struct {
+	ServiceMethod string
+	Seq           uint64
+}
+
+// response mirrors net/rpc.Response — must match exactly for wire compatibility.
+type response struct {
+	ServiceMethod string
+	Seq           uint64
+	Error         string
+}
+
+// rpcClient is a minimal replacement for net/rpc.Client.
+type rpcClient struct {
+	conn io.ReadWriteCloser
+	enc  *gob.Encoder
+	dec  *gob.Decoder
+	mu   sync.Mutex
+	seq  uint64
+}
+
+// newRPCClient creates a new RPC client, equivalent to rpc.NewClient.
+func newRPCClient(conn io.ReadWriteCloser) *rpcClient {
+	return &rpcClient{
+		conn: conn,
+		enc:  gob.NewEncoder(conn),
+		dec:  gob.NewDecoder(conn),
+	}
+}
+
+// Call invokes the named method, waits for it to complete, and returns the error status.
+func (c *rpcClient) Call(serviceMethod string, args any, reply any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.seq++
+	req := request{ServiceMethod: serviceMethod, Seq: c.seq}
+
+	if err := c.enc.Encode(&req); err != nil {
+		return err
+	}
+	if err := c.enc.Encode(args); err != nil {
+		return err
+	}
+
+	var resp response
+	if err := c.dec.Decode(&resp); err != nil {
+		return err
+	}
+	if err := c.dec.Decode(reply); err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return errors.New(resp.Error)
+	}
+	return nil
+}
+
+// Close closes the underlying connection.
+func (c *rpcClient) Close() error {
+	return c.conn.Close()
+}

--- a/client/rpclite.go
+++ b/client/rpclite.go
@@ -1,0 +1,106 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+// rpclite is a minimal RPC client that speaks the same gob-based wire protocol
+// as net/rpc but does not import net/rpc itself. This avoids pulling in
+// net/rpc's debug HTTP handler which depends on html/template, a known blocker
+// for the Go linker's method dead code elimination (DCE) optimization.
+//
+// Wire protocol (identical to net/rpc):
+//   - Client sends: gob-encoded request header, then gob-encoded args
+//   - Server sends: gob-encoded response header, then gob-encoded reply
+//
+// The request/response structs mirror net/rpc.Request and net/rpc.Response
+// exactly, so this client is compatible with existing net/rpc servers.
+
+import (
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"sync"
+)
+
+// request mirrors net/rpc.Request — must match exactly for wire compatibility.
+type request struct {
+	ServiceMethod string
+	Seq           uint64
+}
+
+// response mirrors net/rpc.Response — must match exactly for wire compatibility.
+type response struct {
+	ServiceMethod string
+	Seq           uint64
+	Error         string
+}
+
+// rpcClient is a minimal replacement for net/rpc.Client.
+type rpcClient struct {
+	conn io.ReadWriteCloser
+	enc  *gob.Encoder
+	dec  *gob.Decoder
+	mu   sync.Mutex
+	seq  uint64
+}
+
+// newRPCClient creates a new RPC client, equivalent to rpc.NewClient.
+func newRPCClient(conn io.ReadWriteCloser) *rpcClient {
+	return &rpcClient{
+		conn: conn,
+		enc:  gob.NewEncoder(conn),
+		dec:  gob.NewDecoder(conn),
+	}
+}
+
+// Call invokes the named method, waits for it to complete, and returns the error status.
+func (c *rpcClient) Call(serviceMethod string, args any, reply any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.seq++
+	req := request{ServiceMethod: serviceMethod, Seq: c.seq}
+
+	if err := c.enc.Encode(&req); err != nil {
+		return err
+	}
+	if err := c.enc.Encode(args); err != nil {
+		return err
+	}
+
+	var resp response
+	if err := c.dec.Decode(&resp); err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		// net/rpc's server always writes a body, even for an error response, so it
+		// has to be read off the wire to keep the stream in sync. It must not be
+		// decoded into the caller's reply: the body is a placeholder empty struct,
+		// which fails to decode into the non-struct reply types this package uses
+		// and would mask the server's error message. net/rpc discards it the same
+		// way: a zero reflect.Value tells gob to read the value and throw it away,
+		// and is what Decode(nil) forwards to internally.
+		if err := c.dec.DecodeValue(reflect.Value{}); err != nil {
+			return fmt.Errorf("reading error body: %w", err)
+		}
+		return errors.New(resp.Error)
+	}
+	return c.dec.Decode(reply)
+}
+
+// Close closes the underlying connection.
+func (c *rpcClient) Close() error {
+	return c.conn.Close()
+}

--- a/client/rpclite_test.go
+++ b/client/rpclite_test.go
@@ -1,0 +1,95 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"io"
+	"net/rpc"
+	"testing"
+)
+
+// EchoService is a trivial RPC service for testing wire compatibility.
+type EchoService struct{}
+
+// EchoArgs are the arguments for the Echo method.
+type EchoArgs struct {
+	Msg string
+}
+
+// EchoReply is the reply from the Echo method.
+type EchoReply struct {
+	Msg string
+}
+
+// Echo returns the input message as-is.
+func (e *EchoService) Echo(args EchoArgs, reply *EchoReply) error {
+	reply.Msg = args.Msg
+	return nil
+}
+
+// newTestClientServer creates a connected rpclite client and net/rpc server
+// pair over an in-memory pipe, verifying wire compatibility.
+func newTestClientServer(t *testing.T) *rpcClient {
+	t.Helper()
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+
+	srv := rpc.NewServer()
+	if err := srv.Register(&EchoService{}); err != nil {
+		t.Fatal(err)
+	}
+
+	go srv.ServeConn(&Connection{serverRead, serverWrite})
+
+	return newRPCClient(&Connection{clientRead, clientWrite})
+}
+
+func TestRPCLite_WireCompatibility(t *testing.T) {
+	client := newTestClientServer(t)
+	defer client.Close()
+
+	var reply EchoReply
+	if err := client.Call("EchoService.Echo", EchoArgs{Msg: "hello"}, &reply); err != nil {
+		t.Fatalf("Call: got %v, want nil", err)
+	}
+	if reply.Msg != "hello" {
+		t.Errorf("Call: got reply %q, want %q", reply.Msg, "hello")
+	}
+}
+
+func TestRPCLite_MultipleCalls(t *testing.T) {
+	client := newTestClientServer(t)
+	defer client.Close()
+
+	for i, msg := range []string{"first", "second", "third"} {
+		var reply EchoReply
+		if err := client.Call("EchoService.Echo", EchoArgs{Msg: msg}, &reply); err != nil {
+			t.Fatalf("Call %d: got %v, want nil", i, err)
+		}
+		if reply.Msg != msg {
+			t.Errorf("Call %d: got reply %q, want %q", i, reply.Msg, msg)
+		}
+	}
+}
+
+func TestRPCLite_UnknownMethod(t *testing.T) {
+	client := newTestClientServer(t)
+	defer client.Close()
+
+	var reply EchoReply
+	err := client.Call("EchoService.NoSuchMethod", EchoArgs{}, &reply)
+	if err == nil {
+		t.Fatal("Call unknown method: got nil, want error")
+	}
+}

--- a/client/rpclite_test.go
+++ b/client/rpclite_test.go
@@ -1,0 +1,227 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/rpc"
+	"testing"
+)
+
+// EchoService is a trivial RPC service for testing wire compatibility.
+type EchoService struct{}
+
+// EchoArgs are the arguments for the Echo method.
+type EchoArgs struct {
+	Msg string
+}
+
+// EchoReply is the reply from the Echo method.
+type EchoReply struct {
+	Msg string
+}
+
+// Echo returns the input message as-is.
+func (e *EchoService) Echo(args EchoArgs, reply *EchoReply) error {
+	reply.Msg = args.Msg
+	return nil
+}
+
+// newTestClientServer creates a connected rpclite client and net/rpc server
+// pair over an in-memory pipe, verifying wire compatibility.
+func newTestClientServer(t *testing.T) *rpcClient {
+	t.Helper()
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+
+	srv := rpc.NewServer()
+	if err := srv.Register(&EchoService{}); err != nil {
+		t.Fatal(err)
+	}
+
+	go srv.ServeConn(&Connection{serverRead, serverWrite})
+
+	return newRPCClient(&Connection{clientRead, clientWrite})
+}
+
+func TestRPCLite_WireCompatibility(t *testing.T) {
+	client := newTestClientServer(t)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("Close: got %v, want nil err", err)
+		}
+	})
+
+	var reply EchoReply
+	if err := client.Call("EchoService.Echo", EchoArgs{Msg: "hello"}, &reply); err != nil {
+		t.Fatalf("Call: got %v, want nil", err)
+	}
+	if reply.Msg != "hello" {
+		t.Errorf("Call: got reply %q, want %q", reply.Msg, "hello")
+	}
+}
+
+func TestRPCLite_MultipleCalls(t *testing.T) {
+	client := newTestClientServer(t)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("Close: got %v, want nil err", err)
+		}
+	})
+
+	for i, msg := range []string{"first", "second", "third"} {
+		var reply EchoReply
+		if err := client.Call("EchoService.Echo", EchoArgs{Msg: msg}, &reply); err != nil {
+			t.Fatalf("Call %d: got %v, want nil", i, err)
+		}
+		if reply.Msg != msg {
+			t.Errorf("Call %d: got reply %q, want %q", i, reply.Msg, msg)
+		}
+	}
+}
+
+func TestRPCLite_UnknownMethod(t *testing.T) {
+	client := newTestClientServer(t)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("Close: got %v, want nil err", err)
+		}
+	})
+
+	var reply EchoReply
+	err := client.Call("EchoService.NoSuchMethod", EchoArgs{}, &reply)
+	if err == nil {
+		t.Fatal("Call unknown method: got nil, want error")
+	}
+}
+
+// SignerService mirrors the real signer's method signatures: every reply is a
+// pointer to a slice rather than to a struct, which is what makes the error
+// path below worth testing.
+type SignerService struct{}
+
+// SignerArgs are the arguments for the Sign and FailingSign methods.
+type SignerArgs struct {
+	Digest []byte
+}
+
+// Sign returns a stand-in signature for the given digest.
+func (s *SignerService) Sign(args SignerArgs, reply *[]byte) error {
+	*reply = append([]byte("signed:"), args.Digest...)
+	return nil
+}
+
+// FailingSign always fails, standing in for a signer that rejects a request.
+func (s *SignerService) FailingSign(args SignerArgs, reply *[]byte) error {
+	return errors.New("unsupported hash function")
+}
+
+// rpcCaller is the subset of net/rpc.Client that rpcClient replaces, letting a
+// test drive both implementations through the same calls.
+type rpcCaller interface {
+	Call(serviceMethod string, args any, reply any) error
+	Close() error
+}
+
+// newSignerServer registers SignerService on a net/rpc server reachable over an
+// in-memory pipe and returns the client end of the connection.
+func newSignerServer(t *testing.T) io.ReadWriteCloser {
+	t.Helper()
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+
+	srv := rpc.NewServer()
+	if err := srv.Register(&SignerService{}); err != nil {
+		t.Fatal(err)
+	}
+	go srv.ServeConn(&Connection{serverRead, serverWrite})
+
+	return &Connection{clientRead, clientWrite}
+}
+
+// TestRPCLite_MatchesNetRPC pins rpcClient to net/rpc.Client's observable
+// behaviour: for each call, both clients talk to an identical net/rpc server and
+// must agree on the reply and on the error text.
+func TestRPCLite_MatchesNetRPC(t *testing.T) {
+	testCases := []struct {
+		name      string
+		method    string
+		digest    []byte
+		wantReply []byte
+		wantErr   string
+	}{
+		{
+			name:      "successful call",
+			method:    "SignerService.Sign",
+			digest:    []byte("digest"),
+			wantReply: []byte("signed:digest"),
+		},
+		{
+			name:    "error returned by the service method",
+			method:  "SignerService.FailingSign",
+			digest:  []byte("digest"),
+			wantErr: "unsupported hash function",
+		},
+		{
+			name:    "unknown method",
+			method:  "SignerService.NoSuchMethod",
+			digest:  []byte("digest"),
+			wantErr: "rpc: can't find method SignerService.NoSuchMethod",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			clients := map[string]rpcCaller{
+				"net/rpc": rpc.NewClient(newSignerServer(t)),
+				"rpclite": newRPCClient(newSignerServer(t)),
+			}
+
+			replies := map[string][]byte{}
+			errs := map[string]string{}
+			for name, client := range clients {
+				t.Cleanup(func() {
+					if err := client.Close(); err != nil {
+						t.Errorf("%s: Close: got %v, want nil err", name, err)
+					}
+				})
+
+				var reply []byte
+				err := client.Call(testCase.method, SignerArgs{Digest: testCase.digest}, &reply)
+				replies[name] = reply
+				if err != nil {
+					errs[name] = err.Error()
+				}
+
+				if errs[name] != testCase.wantErr {
+					t.Errorf("%s: Call error = %q, want %q", name, errs[name], testCase.wantErr)
+				}
+				if !bytes.Equal(reply, testCase.wantReply) {
+					t.Errorf("%s: Call reply = %q, want %q", name, reply, testCase.wantReply)
+				}
+			}
+
+			// The point of the exercise: rpclite must be indistinguishable from
+			// net/rpc, not merely correct in isolation.
+			if errs["rpclite"] != errs["net/rpc"] {
+				t.Errorf("error mismatch:\n  rpclite: %q\n  net/rpc: %q", errs["rpclite"], errs["net/rpc"])
+			}
+			if !bytes.Equal(replies["rpclite"], replies["net/rpc"]) {
+				t.Errorf("reply mismatch:\n  rpclite: %q\n  net/rpc: %q", replies["rpclite"], replies["net/rpc"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

`net/rpc` is frozen — no new features since Go 1.20 — and its debug HTTP handler imports `html/template`, which calls `reflect.Value.MethodByName` with a non-constant name. That disables the Go linker's **method dead code elimination** for every binary that transitively imports this package, which is every user of `google-api-go-client` and `cloud.google.com/go`, whether or not they ever load an enterprise certificate.

This is the same class of problem as googleapis/google-cloud-go#8745 (`storage` disabling DCE through `MethodByName`), which was accepted and fixed for the same reason.

## Measured effect

Built with `go build -trimpath -ldflags="-s -w"`, Go 1.26.5, darwin/arm64:

| Binary | main | this PR | Delta |
| --- | --- | --- | --- |
| `signer.so` (this repo's own c-shared artifact) | 5,246,322 B | 3,670,130 B | **−30.0%** |
| minimal program calling `client.Cred` | 4,879,794 B | 3,362,290 B | **−31.1%** |

`html/template` and `net/rpc` account for only a fraction of that; the rest is the methods the linker can drop again once nothing calls `MethodByName` dynamically. Symbol count on the minimal program falls from 7,339 to 5,074.

Dependency check:

```
$ go list -deps ./client | grep -E '^(net/rpc|html/template|text/template)$'
main:      text/template, html/template, net/rpc
this PR:   (none)
```

## Changes

- `client/rpclite.go` — a minimal gob RPC client speaking the **same wire protocol** as `net/rpc`. The `request`/`response` headers mirror `net/rpc.Request`/`net/rpc.Response` field for field, so gob produces identical bytes and existing signer binaries (which run a `net/rpc` server) need no changes.
- `client/client.go` — uses `rpclite` instead of `net/rpc`.
- `client/rpclite_test.go` — drives an `rpclite` client and a `net/rpc` client against identical `net/rpc` servers and asserts they agree on the reply *and* the error text.
- No changes to the signer subprocess side; no new dependencies.

### Error responses

`net/rpc`'s server always writes a body, even for an error response, so it has to be read off the wire to keep the stream in sync — but it must not be decoded into the caller's reply. The body is a placeholder empty struct, and every reply type in this package is a pointer to a slice (`*[]byte`, `*[][]byte`), so decoding it there fails and masks the signer's error message. `rpclite` discards it the way `net/rpc` does, via a zero `reflect.Value`.

The test suite pins this: without it, a signer returning `unsupported hash function` surfaced as `gob: decoding into local type *[]uint8, received remote type = struct { }`.

## Verification

Rebased onto `main` (`3996898`). Locally, on the exact commits pushed:

- `go build ./...`, `go build -buildmode=c-shared ./cshared/...` — clean
- `go test ./client/...` — pass
- `go vet ./client/...` — clean
- `golangci-lint run --max-same-issues 0` in `./client` — 0 issues (matching `main`)
- `gofmt -l client/` — clean
