### PR TITLE
feat: enable ECP with TCP domains

### DIFF
--- a/http_proxy/main.go
+++ b/http_proxy/main.go
@@ -61,9 +61,14 @@ const (
 )
 
 // mtlsGoogleapisHostRegex is a regular expression that validates whether a target
-// host conforms to the "*.mtls.googleapis.com" and "*.mtls.sandbox.googleapis.com" pattern. This is a security
-// measure to ensure the ECPProxy only connects to allowed endpoints.
-var mtlsGoogleapisHostRegex = regexp.MustCompile(`^[a-z0-9-]+(\.mtls(\.sandbox)?\.googleapis\.com|(\.mtls)?\.(apis-tpczero|tpczero)\.goog)$`)
+// host conforms to one of the following allowed mTLS patterns:
+//   - *.mtls.googleapis.com
+//   - *.mtls.sandbox.googleapis.com
+//   - *.mtls.apis-tpczero.goog
+//   - *.mtls.tpczero.goog
+//
+// This is a security measure to ensure the ECPProxy only connects to allowed endpoints.
+var mtlsGoogleapisHostRegex = regexp.MustCompile(`^[a-z0-9-]+\.mtls(\.sandbox)?\.(googleapis\.com|apis-tpczero\.goog|tpczero\.goog)$`)
 
 // AppConfig holds the application configuration parsed from command-line flags.
 type AppConfig struct {

--- a/http_proxy/main.go
+++ b/http_proxy/main.go
@@ -63,7 +63,7 @@ const (
 // mtlsGoogleapisHostRegex is a regular expression that validates whether a target
 // host conforms to the "*.mtls.googleapis.com" and "*.mtls.sandbox.googleapis.com" pattern. This is a security
 // measure to ensure the ECPProxy only connects to allowed endpoints.
-var mtlsGoogleapisHostRegex = regexp.MustCompile(`^[a-z0-9-]+(\.mtls|\.mtls\.sandbox)\.googleapis\.com$`)
+var mtlsGoogleapisHostRegex = regexp.MustCompile(`^[a-z0-9-]+(\.mtls(\.sandbox)?\.googleapis\.com|(\.mtls)?\.(apis-tpczero|tpczero)\.goog)$`)
 
 // AppConfig holds the application configuration parsed from command-line flags.
 type AppConfig struct {
@@ -112,16 +112,16 @@ func newAppConfigFromFlags() (*AppConfig, error) {
 
 // ProxyConfig holds the configuration for the ECPPProxy server.
 type ProxyConfig struct {
-	Port                   int            // The port for the ECPPProxy server to listen on.
-	AllowedMtlsHostsRegex  *regexp.Regexp // Regex to validate allowed mTLS hosts.
-	TlsConfig              *tls.Config    // TLS configuration for mTLS.
-	UpstreamProxyURL       *url.URL       // Optional upstream proxy URL. This will configure the ECPPProxy transport to use this proxy.
-	TLSHandshakeTimeout    time.Duration  // Max duration for TLS handshake to the target.
-	ProxyRequestTimeout    time.Duration  // Max duration for the entire proxy request.
-	DialTimeout            time.Duration  // Max duration for establishing a TCP connection.
-	KeepAlivePeriod        time.Duration  // Period for TCP keep-alives.
-	IdleConnTimeout        time.Duration  // Max duration an idle connection is kept alive.
-	ShutdownTimeout        time.Duration  // Max duration to wait for graceful shutdown.
+	Port                  int            // The port for the ECPPProxy server to listen on.
+	AllowedMtlsHostsRegex *regexp.Regexp // Regex to validate allowed mTLS hosts.
+	TlsConfig             *tls.Config    // TLS configuration for mTLS.
+	UpstreamProxyURL      *url.URL       // Optional upstream proxy URL. This will configure the ECPPProxy transport to use this proxy.
+	TLSHandshakeTimeout   time.Duration  // Max duration for TLS handshake to the target.
+	ProxyRequestTimeout   time.Duration  // Max duration for the entire proxy request.
+	DialTimeout           time.Duration  // Max duration for establishing a TCP connection.
+	KeepAlivePeriod       time.Duration  // Period for TCP keep-alives.
+	IdleConnTimeout       time.Duration  // Max duration an idle connection is kept alive.
+	ShutdownTimeout       time.Duration  // Max duration to wait for graceful shutdown.
 }
 
 // newDefaultProxyConfig creates a new ProxyConfig with default values for timeouts.
@@ -271,8 +271,8 @@ func newReadyzHandler(nonceToken string) http.Handler {
 func runServer(ctx context.Context, proxyConfig *ProxyConfig, handler http.Handler) error {
 	enableECPLogging()
 	server := &http.Server{
-		Addr:     fmt.Sprintf(":%d", proxyConfig.Port),
-		Handler:  handler,
+		Addr:    fmt.Sprintf(":%d", proxyConfig.Port),
+		Handler: handler,
 	}
 
 	// Channel to receive errors from the server's ListenAndServe goroutine.

--- a/http_proxy/main_test.go
+++ b/http_proxy/main_test.go
@@ -240,27 +240,15 @@ func TestIsMtlsHost(t *testing.T) {
 			want:           true,
 		},
 		{
-			name:           "allowed TPC host compute.apis-tpczero.goog",
+			name:           "allowed TPC host compute.mtls.tpczero.goog",
+			mtlsHostsRegex: mtlsGoogleapisHostRegex,
+			host:           "compute.mtls.tpczero.goog",
+			want:           true,
+		},
+		{
+			name:           "disallowed TPC host compute.apis-tpczero.goog rejected",
 			mtlsHostsRegex: mtlsGoogleapisHostRegex,
 			host:           "compute.apis-tpczero.goog",
-			want:           true,
-		},
-		{
-			name:           "allowed TPC host sts.apis-tpczero.goog",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "sts.apis-tpczero.goog",
-			want:           true,
-		},
-		{
-			name:           "allowed TPC host compute.tpczero.goog",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "compute.tpczero.goog",
-			want:           true,
-		},
-		{
-			name:           "disallowed TPC host auth.cloud.tpczero.goog rejected",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "auth.cloud.tpczero.goog",
 			want:           false,
 		},
 		{
@@ -498,7 +486,7 @@ func TestRoutingTransport(t *testing.T) {
 		},
 		{
 			name:        "TPC mTLS Host",
-			host:        "sts.apis-tpczero.goog",
+			host:        "sts.mtls.apis-tpczero.goog",
 			wantECP:     true,
 			wantDefault: false,
 		},

--- a/http_proxy/main_test.go
+++ b/http_proxy/main_test.go
@@ -234,6 +234,42 @@ func TestIsMtlsHost(t *testing.T) {
 			want:           false,
 		},
 		{
+			name:           "allowed TPC host compute.mtls.apis-tpczero.goog",
+			mtlsHostsRegex: mtlsGoogleapisHostRegex,
+			host:           "compute.mtls.apis-tpczero.goog",
+			want:           true,
+		},
+		{
+			name:           "allowed TPC host compute.apis-tpczero.goog",
+			mtlsHostsRegex: mtlsGoogleapisHostRegex,
+			host:           "compute.apis-tpczero.goog",
+			want:           true,
+		},
+		{
+			name:           "allowed TPC host sts.apis-tpczero.goog",
+			mtlsHostsRegex: mtlsGoogleapisHostRegex,
+			host:           "sts.apis-tpczero.goog",
+			want:           true,
+		},
+		{
+			name:           "allowed TPC host compute.tpczero.goog",
+			mtlsHostsRegex: mtlsGoogleapisHostRegex,
+			host:           "compute.tpczero.goog",
+			want:           true,
+		},
+		{
+			name:           "disallowed TPC host auth.cloud.tpczero.goog rejected",
+			mtlsHostsRegex: mtlsGoogleapisHostRegex,
+			host:           "auth.cloud.tpczero.goog",
+			want:           false,
+		},
+		{
+			name:           "disallowed TPC host tpczero.goog rejected",
+			mtlsHostsRegex: mtlsGoogleapisHostRegex,
+			host:           "tpczero.goog",
+			want:           false,
+		},
+		{
 			name:           "localhost regex rejects googleapis",
 			mtlsHostsRegex: localhostRegex,
 			host:           "storage.googleapis.com",
@@ -437,9 +473,9 @@ func TestRoutingTransport(t *testing.T) {
 	defaultRT := &mockRoundTripper{}
 
 	routingRT := &RoutingTransport{
-		ECPTransport:        ecpRT,
-		DefaultTransport:    defaultRT,
-		MtlsHostsRegex: mtlsGoogleapisHostRegex,
+		ECPTransport:     ecpRT,
+		DefaultTransport: defaultRT,
+		MtlsHostsRegex:   mtlsGoogleapisHostRegex,
 	}
 
 	tests := []struct {
@@ -457,6 +493,12 @@ func TestRoutingTransport(t *testing.T) {
 		{
 			name:        "Allowed API Host",
 			host:        "reauth.googleapis.com",
+			wantECP:     false,
+			wantDefault: true,
+		},
+		{
+			name:        "TPC mTLS Host",
+			host:        "sts.apis-tpczero.goog",
 			wantECP:     true,
 			wantDefault: false,
 		},


### PR DESCRIPTION
Enable mTLS certificate with domains apis-tpczero.goog and tpczero.goog. Also, fix unit test broken at head.