### PR TITLE
feat: Simplify mTLS filtering logic in ECP HTTP Proxy

### DIFF
--- a/http_proxy/main.go
+++ b/http_proxy/main.go
@@ -34,7 +34,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"regexp"
+	"strings"
 	"syscall"
 	"time"
 
@@ -60,10 +60,6 @@ const (
 	defaultShutdownTimeout     = 5 * time.Second
 )
 
-// mtlsGoogleapisHostRegex is a regular expression that validates whether a target
-// host conforms to the "*.mtls.googleapis.com" and "*.mtls.sandbox.googleapis.com" pattern. This is a security
-// measure to ensure the ECPProxy only connects to allowed endpoints.
-var mtlsGoogleapisHostRegex = regexp.MustCompile(`^[a-z0-9-]+(\.mtls|\.mtls\.sandbox)\.googleapis\.com$`)
 
 // AppConfig holds the application configuration parsed from command-line flags.
 type AppConfig struct {
@@ -113,7 +109,6 @@ func newAppConfigFromFlags() (*AppConfig, error) {
 // ProxyConfig holds the configuration for the ECPPProxy server.
 type ProxyConfig struct {
 	Port                   int            // The port for the ECPPProxy server to listen on.
-	AllowedMtlsHostsRegex  *regexp.Regexp // Regex to validate allowed mTLS hosts.
 	TlsConfig              *tls.Config    // TLS configuration for mTLS.
 	UpstreamProxyURL       *url.URL       // Optional upstream proxy URL. This will configure the ECPPProxy transport to use this proxy.
 	TLSHandshakeTimeout    time.Duration  // Max duration for TLS handshake to the target.
@@ -163,12 +158,6 @@ func writeError(w http.ResponseWriter, originalError error, errorMsg string, sta
 	}
 }
 
-// isMtlsHost checks if the provided host string matches the predefined
-// regular expression for allowed mTLS hosts.
-func isMtlsHost(mtlsHostsRegex *regexp.Regexp, host string) bool {
-	return mtlsHostsRegex.MatchString(host)
-}
-
 // newTransport creates an http.RoundTripper configured with the given TLS config
 // and optional upstream proxy.
 func newTransport(tlsConfig *tls.Config, proxyConfig *ProxyConfig) http.RoundTripper {
@@ -197,16 +186,16 @@ func newTransport(tlsConfig *tls.Config, proxyConfig *ProxyConfig) http.RoundTri
 type RoutingTransport struct {
 	ECPTransport     http.RoundTripper
 	DefaultTransport http.RoundTripper
-	MtlsHostsRegex   *regexp.Regexp
 }
 
 // RoundTrip executes a single HTTP transaction, routing it to the appropriate transport.
 func (t *RoutingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if isMtlsHost(t.MtlsHostsRegex, req.URL.Host) {
+	if strings.Contains(req.URL.Host, "mtls") {
 		return t.ECPTransport.RoundTrip(req)
 	}
 	return t.DefaultTransport.RoundTrip(req)
 }
+
 
 // newECPProxyHandler creates the primary http.Handler for the ECP Proxy server.
 // It uses httputil.ReverseProxy to forward requests.
@@ -310,7 +299,6 @@ func run(ctx context.Context, cfg *AppConfig) error {
 	log.Print("Starting ECP Proxy...")
 
 	proxyConfig := newDefaultProxyConfig()
-	proxyConfig.AllowedMtlsHostsRegex = mtlsGoogleapisHostRegex
 	proxyConfig.Port = cfg.Port
 
 	// Create tlsConfig
@@ -350,7 +338,6 @@ func run(ctx context.Context, cfg *AppConfig) error {
 	routingTransport := &RoutingTransport{
 		ECPTransport:     ecpTransport,
 		DefaultTransport: defaultTransport,
-		MtlsHostsRegex:   proxyConfig.AllowedMtlsHostsRegex,
 	}
 
 	// Create a ServeMux to route requests.

--- a/http_proxy/main.go
+++ b/http_proxy/main.go
@@ -60,7 +60,6 @@ const (
 	defaultShutdownTimeout     = 5 * time.Second
 )
 
-
 // AppConfig holds the application configuration parsed from command-line flags.
 type AppConfig struct {
 	Port                             int
@@ -108,15 +107,15 @@ func newAppConfigFromFlags() (*AppConfig, error) {
 
 // ProxyConfig holds the configuration for the ECPPProxy server.
 type ProxyConfig struct {
-	Port                   int            // The port for the ECPPProxy server to listen on.
-	TlsConfig              *tls.Config    // TLS configuration for mTLS.
-	UpstreamProxyURL       *url.URL       // Optional upstream proxy URL. This will configure the ECPPProxy transport to use this proxy.
-	TLSHandshakeTimeout    time.Duration  // Max duration for TLS handshake to the target.
-	ProxyRequestTimeout    time.Duration  // Max duration for the entire proxy request.
-	DialTimeout            time.Duration  // Max duration for establishing a TCP connection.
-	KeepAlivePeriod        time.Duration  // Period for TCP keep-alives.
-	IdleConnTimeout        time.Duration  // Max duration an idle connection is kept alive.
-	ShutdownTimeout        time.Duration  // Max duration to wait for graceful shutdown.
+	Port                int           // The port for the ECPPProxy server to listen on.
+	TlsConfig           *tls.Config   // TLS configuration for mTLS.
+	UpstreamProxyURL    *url.URL      // Optional upstream proxy URL. This will configure the ECPPProxy transport to use this proxy.
+	TLSHandshakeTimeout time.Duration // Max duration for TLS handshake to the target.
+	ProxyRequestTimeout time.Duration // Max duration for the entire proxy request.
+	DialTimeout         time.Duration // Max duration for establishing a TCP connection.
+	KeepAlivePeriod     time.Duration // Period for TCP keep-alives.
+	IdleConnTimeout     time.Duration // Max duration an idle connection is kept alive.
+	ShutdownTimeout     time.Duration // Max duration to wait for graceful shutdown.
 }
 
 // newDefaultProxyConfig creates a new ProxyConfig with default values for timeouts.
@@ -196,7 +195,6 @@ func (t *RoutingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	return t.DefaultTransport.RoundTrip(req)
 }
 
-
 // newECPProxyHandler creates the primary http.Handler for the ECP Proxy server.
 // It uses httputil.ReverseProxy to forward requests.
 func newECPProxyHandler(transport http.RoundTripper) http.Handler {
@@ -260,8 +258,8 @@ func newReadyzHandler(nonceToken string) http.Handler {
 func runServer(ctx context.Context, proxyConfig *ProxyConfig, handler http.Handler) error {
 	enableECPLogging()
 	server := &http.Server{
-		Addr:     fmt.Sprintf(":%d", proxyConfig.Port),
-		Handler:  handler,
+		Addr:    fmt.Sprintf(":%d", proxyConfig.Port),
+		Handler: handler,
 	}
 
 	// Channel to receive errors from the server's ListenAndServe goroutine.

--- a/http_proxy/main.go
+++ b/http_proxy/main.go
@@ -190,7 +190,7 @@ type RoutingTransport struct {
 
 // RoundTrip executes a single HTTP transaction, routing it to the appropriate transport.
 func (t *RoutingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if strings.Contains(req.URL.Host, "mtls") {
+	if strings.Contains(req.URL.Host, ".mtls.") {
 		return t.ECPTransport.RoundTrip(req)
 	}
 	return t.DefaultTransport.RoundTrip(req)

--- a/http_proxy/main_test.go
+++ b/http_proxy/main_test.go
@@ -490,7 +490,7 @@ func TestRoutingTransport(t *testing.T) {
 		},
 		{
 			name:        "Host with mtls",
-			host:        "mtls.example.com",
+			host:        "example.mtls.com",
 			wantECP:     true,
 			wantDefault: false,
 		},

--- a/http_proxy/main_test.go
+++ b/http_proxy/main_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"regexp"
 	"testing"
 )
 
@@ -36,7 +35,6 @@ const (
 
 var (
 	testPath       = fmt.Sprintf("http://localhost:%d/some/path", testPort)
-	localhostRegex = regexp.MustCompile(`^127\.0\.0\.1:(\d{1,5})$`)
 )
 
 func TestAppConfigFromFlags(t *testing.T) {
@@ -148,114 +146,6 @@ func TestAppConfigFromFlags(t *testing.T) {
 	}
 }
 
-func TestIsMtlsHost(t *testing.T) {
-	tests := []struct {
-		name           string
-		mtlsHostsRegex *regexp.Regexp
-		host           string
-		want           bool
-	}{
-		{
-			name:           "allowed host storage.mtls.googleapis.com",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "storage.mtls.googleapis.com",
-			want:           true,
-		},
-		{
-			name:           "allowed host storage.mtls.sandbox.googleapis.com",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "storage.mtls.sandbox.googleapis.com",
-			want:           true,
-		},
-		{
-			name:           "allowed host with numbers",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "my-service-123.mtls.googleapis.com",
-			want:           true,
-		},
-		{
-			name:           "disallowed host google.com rejected",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "google.com",
-			want:           false,
-		},
-		{
-			name:           "disallowed host evil.com rejected",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "evil.com",
-			want:           false,
-		},
-		{
-			name:           "disallowed host with fake subdomain rejected",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "storage.mtls.googleapis.com.fake.com",
-			want:           false,
-		},
-		{
-			name:           "disallowed host with fake prefix rejected",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "a/b/c/storage.mtls.googleapis.com.",
-			want:           false,
-		},
-		{
-			name:           "allowed host with numbers",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "my-service-123.mtls.sandbox.googleapis.com",
-			want:           true,
-		},
-		{
-			name:           "disallowed host sandbox.google.com rejected",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "sandbox.google.com",
-			want:           false,
-		},
-		{
-			name:           "disallowed host sandbox.evil.com rejected",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "sandbox.evil.com",
-			want:           false,
-		},
-		{
-			name:           "disallowed host with fake subdomain rejected",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "storage.mtls.sandbox.googleapis.com.fake.com",
-			want:           false,
-		},
-		{
-			name:           "disallowed host with fake prefix rejected",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "a/b/c/storage.mtls.sandbox.googleapis.com.",
-			want:           false,
-		},
-		{
-			name:           "disallowed host - empty string",
-			mtlsHostsRegex: mtlsGoogleapisHostRegex,
-			host:           "",
-			want:           false,
-		},
-		{
-			name:           "localhost regex rejects googleapis",
-			mtlsHostsRegex: localhostRegex,
-			host:           "storage.googleapis.com",
-			want:           false,
-		},
-		{
-			name:           "localhost regex allows localhost",
-			mtlsHostsRegex: localhostRegex,
-			host:           "127.0.0.1:8080",
-			want:           true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isMtlsHost(tt.mtlsHostsRegex, tt.host); got != tt.want {
-				t.Errorf("isMtlsHost(%s, %q) = %v, want %v", tt.mtlsHostsRegex.String(), tt.host, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestWriteError(t *testing.T) {
 	rr := httptest.NewRecorder()
 	originalErr := errors.New("original error")
@@ -324,7 +214,6 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 func NewProxyConfigForTest() *ProxyConfig {
 	proxyConfig := newDefaultProxyConfig()
 	proxyConfig.Port = testPort
-	proxyConfig.AllowedMtlsHostsRegex = mtlsGoogleapisHostRegex
 	return proxyConfig
 }
 
@@ -426,79 +315,6 @@ func TestNewECPProxyHandler(t *testing.T) {
 				}
 				if errResp.Error == "" {
 					t.Errorf("Expected error response 'Error' field to be non-empty")
-				}
-			}
-		})
-	}
-}
-
-func TestRoutingTransport(t *testing.T) {
-	ecpRT := &mockRoundTripper{}
-	defaultRT := &mockRoundTripper{}
-
-	routingRT := &RoutingTransport{
-		ECPTransport:        ecpRT,
-		DefaultTransport:    defaultRT,
-		MtlsHostsRegex: mtlsGoogleapisHostRegex,
-	}
-
-	tests := []struct {
-		name        string
-		host        string
-		wantECP     bool
-		wantDefault bool
-	}{
-		{
-			name:        "mTLS Host",
-			host:        "storage.mtls.googleapis.com",
-			wantECP:     true,
-			wantDefault: false,
-		},
-		{
-			name:        "Allowed API Host",
-			host:        "reauth.googleapis.com",
-			wantECP:     true,
-			wantDefault: false,
-		},
-		{
-			name:        "Regular Host",
-			host:        "google.com",
-			wantECP:     false,
-			wantDefault: true,
-		},
-		{
-			name:        "Disallowed mTLS-like Host",
-			host:        "evil.mtls.googleapis.com.fake.com",
-			wantECP:     false,
-			wantDefault: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Reset mocks
-			ecpRT.capturedRequest = nil
-			defaultRT.capturedRequest = nil
-
-			req := httptest.NewRequest(http.MethodGet, "https://"+tt.host, nil)
-			_, err := routingRT.RoundTrip(req)
-			if err != nil {
-				t.Fatalf("RoundTrip failed: %v", err)
-			}
-
-			if tt.wantECP {
-				if ecpRT.capturedRequest == nil {
-					t.Error("Expected ECP transport to be used, but it wasn't")
-				}
-				if defaultRT.capturedRequest != nil {
-					t.Error("Expected Default transport NOT to be used, but it was")
-				}
-			} else if tt.wantDefault {
-				if defaultRT.capturedRequest == nil {
-					t.Error("Expected Default transport to be used, but it wasn't")
-				}
-				if ecpRT.capturedRequest != nil {
-					t.Error("Expected ECP transport NOT to be used, but it was")
 				}
 			}
 		})
@@ -643,4 +459,70 @@ func TestMuxRouting(t *testing.T) {
 			t.Errorf("Expected path %q, got %q", "/some/path", mockRT.capturedRequest.URL.Path)
 		}
 	})
+}
+
+func TestRoutingTransport(t *testing.T) {
+	ecpRT := &mockRoundTripper{}
+	defaultRT := &mockRoundTripper{}
+
+	routingRT := &RoutingTransport{
+		ECPTransport:        ecpRT,
+		DefaultTransport:    defaultRT,
+	}
+
+	tests := []struct {
+		name        string
+		host        string
+		wantECP     bool
+		wantDefault bool
+	}{
+		{
+			name:        "mTLS Host",
+			host:        "storage.mtls.googleapis.com",
+			wantECP:     true,
+			wantDefault: false,
+		},
+		{
+			name:        "Regular Host",
+			host:        "google.com",
+			wantECP:     false,
+			wantDefault: true,
+		},
+		{
+			name:        "Host with mtls",
+			host:        "mtls.example.com",
+			wantECP:     true,
+			wantDefault: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset mocks
+			ecpRT.capturedRequest = nil
+			defaultRT.capturedRequest = nil
+
+			req := httptest.NewRequest(http.MethodGet, "https://"+tt.host, nil)
+			_, err := routingRT.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("RoundTrip failed: %v", err)
+			}
+
+			if tt.wantECP {
+				if ecpRT.capturedRequest == nil {
+					t.Error("Expected ECP transport to be used, but it wasn't")
+				}
+				if defaultRT.capturedRequest != nil {
+					t.Error("Expected Default transport NOT to be used, but it was")
+				}
+			} else if tt.wantDefault {
+				if defaultRT.capturedRequest == nil {
+					t.Error("Expected Default transport to be used, but it wasn't")
+				}
+				if ecpRT.capturedRequest != nil {
+					t.Error("Expected ECP transport NOT to be used, but it was")
+				}
+			}
+		})
+	}
 }

--- a/http_proxy/main_test.go
+++ b/http_proxy/main_test.go
@@ -34,7 +34,7 @@ const (
 )
 
 var (
-	testPath       = fmt.Sprintf("http://localhost:%d/some/path", testPort)
+	testPath = fmt.Sprintf("http://localhost:%d/some/path", testPort)
 )
 
 func TestAppConfigFromFlags(t *testing.T) {
@@ -466,8 +466,8 @@ func TestRoutingTransport(t *testing.T) {
 	defaultRT := &mockRoundTripper{}
 
 	routingRT := &RoutingTransport{
-		ECPTransport:        ecpRT,
-		DefaultTransport:    defaultRT,
+		ECPTransport:     ecpRT,
+		DefaultTransport: defaultRT,
 	}
 
 	tests := []struct {

--- a/http_proxy/proxy_http_test.go
+++ b/http_proxy/proxy_http_test.go
@@ -35,7 +35,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"regexp"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -179,11 +179,11 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 	passthroughProxyServer := httptest.NewServer(http.HandlerFunc(ProxyHandler))
 	defer passthroughProxyServer.Close()
 
-	validMTLSBackendServerHost := validMTLSBackendServer.Listener.Addr().String()       // e.g. "127.0.0.1:12345"
-	backendServerReturnsErrorHost := backendServerReturnsError.Listener.Addr().String() // e.g. "127.0.0.1:12345"
+	validMTLSBackendServerHost := strings.Replace(validMTLSBackendServer.Listener.Addr().String(), "127.0.0.1", "mtls.test", 1)
+	backendServerReturnsErrorHost := strings.Replace(backendServerReturnsError.Listener.Addr().String(), "127.0.0.1", "mtls.test", 1)
 	plainBackendServerHost := plainBackendServer.Listener.Addr().String()
 	validPassthroughURL := passthroughProxyServer.URL
-	invalidPassthroughURL := "1234-bad-server.com"
+	invalidPassthroughURL := "1234-bad-server-mtls.com"
 
 	testCases := []struct {
 		name                    string
@@ -215,7 +215,7 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 		{
 			name:                    "invalid target header (dns failure)",
 			ecpMTLSCerts:            certs1,
-			targetHostHeader:        "123-not-allowed.com",
+			targetHostHeader:        "123-not-allowed-mtls.com",
 			passthroughProxyAddress: "",
 			wantStatusCode:          http.StatusBadGateway,
 			wantECPProxyError:       true,
@@ -310,7 +310,6 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 
 			proxyConfig := &ProxyConfig{
 				Port:                  ecpProxyPort,
-				AllowedMtlsHostsRegex: regexp.MustCompile(".*"),
 				TlsConfig:             tlsConfig,
 			}
 
@@ -322,19 +321,28 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 				proxyConfig.UpstreamProxyURL = passthroughProxyServerURL
 			}
 
-			ecpTransport := newTransport(proxyConfig.TlsConfig, proxyConfig)
-			
+			ecpTransport := newTransport(proxyConfig.TlsConfig, proxyConfig).(*http.Transport)
+
 			defaultTLSConfig := &tls.Config{
 				RootCAs:            tc.ecpMTLSCerts.CAPool,
 				InsecureSkipVerify: true,
 				ServerName:         "localhost",
 			}
-			defaultTransport := newTransport(defaultTLSConfig, proxyConfig)
+			defaultTransport := newTransport(defaultTLSConfig, proxyConfig).(*http.Transport)
+
+			customDialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
+				addr = strings.Replace(addr, "mtls.test", "127.0.0.1", 1)
+				return (&net.Dialer{
+					Timeout:   proxyConfig.DialTimeout,
+					KeepAlive: proxyConfig.KeepAlivePeriod,
+				}).DialContext(ctx, network, addr)
+			}
+			ecpTransport.DialContext = customDialContext
+			defaultTransport.DialContext = customDialContext
 
 			routingTransport := &RoutingTransport{
 				ECPTransport:     ecpTransport,
 				DefaultTransport: defaultTransport,
-				MtlsHostsRegex:   proxyConfig.AllowedMtlsHostsRegex,
 			}
 
 			handler := newECPProxyHandler(routingTransport)

--- a/http_proxy/proxy_http_test.go
+++ b/http_proxy/proxy_http_test.go
@@ -311,8 +311,8 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 			}
 
 			proxyConfig := &ProxyConfig{
-				Port:                  ecpProxyPort,
-				TlsConfig:             tlsConfig,
+				Port:      ecpProxyPort,
+				TlsConfig: tlsConfig,
 			}
 
 			if tc.passthroughProxyAddress != "" {

--- a/http_proxy/proxy_http_test.go
+++ b/http_proxy/proxy_http_test.go
@@ -179,8 +179,8 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 	passthroughProxyServer := httptest.NewServer(http.HandlerFunc(ProxyHandler))
 	defer passthroughProxyServer.Close()
 
-	validMTLSBackendServerHost := strings.Replace(validMTLSBackendServer.Listener.Addr().String(), "127.0.0.1", "mtls.test", 1)
-	backendServerReturnsErrorHost := strings.Replace(backendServerReturnsError.Listener.Addr().String(), "127.0.0.1", "mtls.test", 1)
+	validMTLSBackendServerHost := strings.Replace(validMTLSBackendServer.Listener.Addr().String(), "127.0.0.1", "test.mtls.local", 1)
+	backendServerReturnsErrorHost := strings.Replace(backendServerReturnsError.Listener.Addr().String(), "127.0.0.1", "test.mtls.local", 1)
 	plainBackendServerHost := plainBackendServer.Listener.Addr().String()
 	validPassthroughURL := passthroughProxyServer.URL
 	invalidPassthroughURL := "1234-bad-server-mtls.com"
@@ -331,7 +331,7 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 			defaultTransport := newTransport(defaultTLSConfig, proxyConfig).(*http.Transport)
 
 			customDialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
-				addr = strings.Replace(addr, "mtls.test", "127.0.0.1", 1)
+				addr = strings.Replace(addr, "test.mtls.local", "127.0.0.1", 1)
 				return (&net.Dialer{
 					Timeout:   proxyConfig.DialTimeout,
 					KeepAlive: proxyConfig.KeepAlivePeriod,

--- a/http_proxy/proxy_http_test.go
+++ b/http_proxy/proxy_http_test.go
@@ -179,6 +179,8 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 	passthroughProxyServer := httptest.NewServer(http.HandlerFunc(ProxyHandler))
 	defer passthroughProxyServer.Close()
 
+	// To trick the proxy into selecting the ECPTransport (mTLS), the target host must contain ".mtls.".
+	// We replace the local IP (127.0.0.1) from our mock servers with "test.mtls.local" in the request headers.
 	validMTLSBackendServerHost := strings.Replace(validMTLSBackendServer.Listener.Addr().String(), "127.0.0.1", "test.mtls.local", 1)
 	backendServerReturnsErrorHost := strings.Replace(backendServerReturnsError.Listener.Addr().String(), "127.0.0.1", "test.mtls.local", 1)
 	plainBackendServerHost := plainBackendServer.Listener.Addr().String()
@@ -330,6 +332,9 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 			}
 			defaultTransport := newTransport(defaultTLSConfig, proxyConfig).(*http.Transport)
 
+			// Because we tricked the proxy with the fake domain "test.mtls.local" above to trigger mTLS,
+			// the actual TCP dial will fail DNS resolution. We use a custom DialContext to intercept this
+			// fake domain and redirect the connection back to 127.0.0.1 where the mock server is listening.
 			customDialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
 				addr = strings.Replace(addr, "test.mtls.local", "127.0.0.1", 1)
 				return (&net.Dialer{

--- a/http_proxy/test_passthrough_proxy.go
+++ b/http_proxy/test_passthrough_proxy.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -87,7 +88,8 @@ func handleHTTP(w http.ResponseWriter, r *http.Request) {
 // handleTunneling handles CONNECT requests for setting up an HTTPS tunnel.
 func handleTunneling(w http.ResponseWriter, r *http.Request) {
 	// Establish a TCP connection to the target host
-	destConn, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
+	host := strings.Replace(r.Host, "mtls.test", "127.0.0.1", 1)
+	destConn, err := net.DialTimeout("tcp", host, 10*time.Second)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return

--- a/http_proxy/test_passthrough_proxy.go
+++ b/http_proxy/test_passthrough_proxy.go
@@ -88,7 +88,7 @@ func handleHTTP(w http.ResponseWriter, r *http.Request) {
 // handleTunneling handles CONNECT requests for setting up an HTTPS tunnel.
 func handleTunneling(w http.ResponseWriter, r *http.Request) {
 	// Establish a TCP connection to the target host
-	host := strings.Replace(r.Host, "mtls.test", "127.0.0.1", 1)
+	host := strings.Replace(r.Host, "test.mtls.local", "127.0.0.1", 1)
 	destConn, err := net.DialTimeout("tcp", host, 10*time.Second)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)

--- a/http_proxy/test_passthrough_proxy.go
+++ b/http_proxy/test_passthrough_proxy.go
@@ -87,7 +87,9 @@ func handleHTTP(w http.ResponseWriter, r *http.Request) {
 
 // handleTunneling handles CONNECT requests for setting up an HTTPS tunnel.
 func handleTunneling(w http.ResponseWriter, r *http.Request) {
-	// Establish a TCP connection to the target host
+	// Establish a TCP connection to the target host.
+	// Note: We intercept the fake "test.mtls.local" domain (used by the proxy tests to force mTLS routing)
+	// and rewrite it to 127.0.0.1 so this dummy proxy can successfully dial the local mock server.
 	host := strings.Replace(r.Host, "test.mtls.local", "127.0.0.1", 1)
 	destConn, err := net.DialTimeout("tcp", host, 10*time.Second)
 	if err != nil {


### PR DESCRIPTION
Remove the strict regular expression-based filtering for mTLS target hosts in the ECP HTTP proxy and replace it with a generic `.mtls.` substring check.

The proxy now uses:
```
if strings.Contains(req.URL.Host, ".mtls.") {
    return t.ECPTransport.RoundTrip(req)
}
```

# Example List of Hosts 
## Will route through mTLS (ECPTransport)
These hosts contain .mtls. (dots on both sides):
- storage.mtls.googleapis.com
- pubsub.mtls.sandbox.googleapis.com
- foo.mtls.apis-tpczero.goog (matches the *.mtls.apis-tpczero.goog pattern)
- bar.mtls.tpczero.goog (matches the *.mtls.tpczero.goog pattern)
- internal.mtls.example.com

## These example hosts do NOT route through mTLS (falls back to DefaultTransport)
These hosts do not satisfy the .mtls. substring check:

- storage.googleapis.com (does not contain mtls)
- google.com (does not contain mtls)
- mymtlsdomain.com (contains mtls but is missing the dot boundaries)
- mtls.googleapis.com (contains .googleapis.com, but lacks a leading dot before mtls)

