### PR TITLE
chore: Remove windows ECP DWARF debug symbols.

### DIFF
--- a/build/scripts/windows_amd64.ps1
+++ b/build/scripts/windows_amd64.ps1
@@ -34,7 +34,7 @@ Set-Location ..\
 
 # Build the signer library
 # TODO: Add build version to shared DLL. https://github.com/googleapis/enterprise-certificate-proxy/issues/103
-go build -buildmode=c-shared -o .\build\bin\windows_amd64\libecp.dll .\cshared\main.go
+go build -buildmode=c-shared -ldflags="-s -w" -o .\build\bin\windows_amd64\libecp.dll .\cshared\main.go
 go build -buildmode=c-archive -o .\build\bin\windows_amd64\libecp.lib .\cshared\main.go
 
 Remove-Item .\build\bin\windows_amd64\libecp.h


### PR DESCRIPTION
After updating ECP to use go 1.25.8, integration tests failed.

```
OSError: [WinError 193] %1 is not a valid Win32 application
ERROR: gcloud crashed (OSError): [WinError 193] %1 is not a valid Win32 application
```

This is a known issue in recent Go versions: https://github.com/golang/go/issues/77886

When building c-shared libraries (DLLs) on Windows with CGO enabled, the Go linker generates a malformed PE (Portable Executable) file when including DWARF debug symbols. While tools like file might still report it as a valid PE32+ binary, the Windows loader rejects it, resulting in the `WinError 193` error.

