### PR TITLE
fix: mTLS routing for hosts starting with 'mtls.'

### DIFF
--- a/http_proxy/main.go
+++ b/http_proxy/main.go
@@ -189,7 +189,10 @@ type RoutingTransport struct {
 
 // RoundTrip executes a single HTTP transaction, routing it to the appropriate transport.
 func (t *RoutingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if strings.Contains(req.URL.Host, ".mtls.") {
+	// Route to ECP transport (mTLS) if the host is an mTLS endpoint.
+	// - Contains ".mtls." matches standard Google API mTLS hosts (e.g., compute.mtls.googleapis.com).
+	// - Starts with "mtls." matches IAP tunnel WebSocket hosts (e.g., mtls.tunnel.cloudproxy.app).
+	if strings.Contains(req.URL.Host, ".mtls.") || strings.HasPrefix(req.URL.Host, "mtls.") {
 		return t.ECPTransport.RoundTrip(req)
 	}
 	return t.DefaultTransport.RoundTrip(req)

--- a/http_proxy/main_test.go
+++ b/http_proxy/main_test.go
@@ -494,6 +494,12 @@ func TestRoutingTransport(t *testing.T) {
 			wantECP:     true,
 			wantDefault: false,
 		},
+		{
+			name:        "Host starting with mtls (WebSocket)",
+			host:        "mtls.tunnel.cloudproxy.app",
+			wantECP:     true,
+			wantDefault: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/http_proxy/proxy_http_test.go
+++ b/http_proxy/proxy_http_test.go
@@ -182,6 +182,7 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 	// To trick the proxy into selecting the ECPTransport (mTLS), the target host must contain ".mtls.".
 	// We replace the local IP (127.0.0.1) from our mock servers with "test.mtls.local" in the request headers.
 	validMTLSBackendServerHost := strings.Replace(validMTLSBackendServer.Listener.Addr().String(), "127.0.0.1", "test.mtls.local", 1)
+	mtlsValidMTLSBackendServerHost := strings.Replace(validMTLSBackendServer.Listener.Addr().String(), "127.0.0.1", "mtls.test.local", 1)
 	backendServerReturnsErrorHost := strings.Replace(backendServerReturnsError.Listener.Addr().String(), "127.0.0.1", "test.mtls.local", 1)
 	plainBackendServerHost := plainBackendServer.Listener.Addr().String()
 	validPassthroughURL := passthroughProxyServer.URL
@@ -196,6 +197,15 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 		expectedResponseBody    string
 		wantECPProxyError       bool
 	}{
+		{
+			name:                    "successful request with mtls. prefix",
+			ecpMTLSCerts:            certs1,
+			targetHostHeader:        mtlsValidMTLSBackendServerHost,
+			passthroughProxyAddress: "",
+			wantStatusCode:          http.StatusOK,
+			expectedResponseBody:    successMessage,
+			wantECPProxyError:       false,
+		},
 		{
 			name:                    "successful request",
 			ecpMTLSCerts:            certs1,
@@ -299,9 +309,9 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ecpProxyPort := 8080
+			ecpProxyPort := 8080 + i
 
 			tlsConfig := &tls.Config{
 				Certificates:       []tls.Certificate{tc.ecpMTLSCerts.ClientCert},
@@ -337,6 +347,7 @@ func TestECPProxyWithHTTPClient(t *testing.T) {
 			// fake domain and redirect the connection back to 127.0.0.1 where the mock server is listening.
 			customDialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
 				addr = strings.Replace(addr, "test.mtls.local", "127.0.0.1", 1)
+				addr = strings.Replace(addr, "mtls.test.local", "127.0.0.1", 1)
 				return (&net.Dialer{
 					Timeout:   proxyConfig.DialTimeout,
 					KeepAlive: proxyConfig.KeepAlivePeriod,


### PR DESCRIPTION
The ECP proxy determines whether to route a request via the mTLS transport by checking if the target host contains ".mtls.".

However, the IAP WebSocket host is "mtls.tunnel.cloudproxy.app", which starts with "mtls." but does not contain ".mtls." (lacking the leading dot). As a result, IAP WebSocket connections were routed via the default transport without the mTLS client certificate, failing authentication with error 4033.

This change updates RoutingTransport to match hosts that either contain ".mtls." or start with "mtls.", ensuring IAP WebSockets are correctly routed via mTLS.

Also:
- Added a unit test case in TestRoutingTransport.
- Added an integration test case in TestECPProxyWithHTTPClient.
- Fixed a port-reuse flakiness issue in TestECPProxyWithHTTPClient by using unique ports for each test case.