### PR TITLE
fix: use legacy OpenSSL algorithms for keychain import

### DIFF
--- a/scripts/keychain_cred.sh
+++ b/scripts/keychain_cred.sh
@@ -23,7 +23,7 @@ KEYCHAIN_TEST_BINARY=$(echo "$PWD/$(find . -iname keychain.test)")
 pushd "${WORK_DIR}"
 
 openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -sha256 -days 5 -nodes -subj "/C=US/ST=WA/L=Kirkland/O=Temp/OU=CI/CN=TestIssuer/emailAddress=dev@example.com" 
-openssl pkcs12 -inkey key.pem -in cert.pem -export -out cred.p12 -passin pass:${PASSWORD} -passout pass:${PASSWORD}
+openssl pkcs12 -inkey key.pem -in cert.pem -export -out cred.p12 -passin pass:${PASSWORD} -passout pass:${PASSWORD} -legacy
 
 security create-keychain -p ${PASSWORD} ${KEYCHAIN}
 


### PR DESCRIPTION
Add the `-legacy` flag to `openssl pkcs12` to fix a MAC verification failure during import on macOS runners using OpenSSL 3.x.